### PR TITLE
Station mule debug

### DIFF
--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -91,7 +91,7 @@
 				<wait exact="100ms" />
 			</do_if>
 
-			<!-- Add trade wares to target station -->
+			<!-- Add trade ware orders to target station if make target warehouse is checked-->
 			<do_if value="$allowCreateTrade and ($targetStation.owner == this.ship.owner)">
 				<set_value name="$sourceTradeWares" exact="0" />
 				<set_value name="$targetTradeWares" exact="0" />
@@ -248,7 +248,9 @@
 										</do_else>
 
 										<!--never trade between warehouses -->
-										<do_if value="not ($supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists and $supplySource.owner.tradewares.{$supplyTarget.ware}.exists)">
+										<set_value name="$sourceIsWarehouse" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists and not $supplySource.owner.products.{$supplySource.ware}.exists"/>
+										<set_value name="$targetIsWarehouse" exact="$supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists and not $supplyTarget.owner.products.{$supplyTarget.ware}.exists"/>
+										<do_if value="not ($sourceIsWarehouse and $targetIsWarehouse)">
 											<do_if value="$supplyTarget.owner.owner == this.ship.owner">
 												<set_value name="$targetAmount" exact="$supplyTarget.desiredamount" />
 											</do_if>
@@ -258,6 +260,7 @@
 
 											<!--$cargoHauled == $targetAmount means it is the last few units needed to finish a station or drones-->
 											<set_value name="$cargoHauled" exact="[this.ship.cargo.{$supplyTarget.ware}.free,$targetAmount,$supplySource.amount].min" />
+											<set_value name="$tradeThis" exact="$cargoHauled gt 0 and ($allowLowVol or $cargoHauled gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($cargoHauled == $targetAmount and ($supplyTarget.owner.class == class.buildstorage or $supplyTarget.owner.cargo.{$supplyTarget.ware}.target == 0)))"/>
 											<do_if value="$cargoHauled gt 0 and ($allowLowVol or $cargoHauled gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($cargoHauled == $targetAmount and ($supplyTarget.owner.class == class.buildstorage or $supplyTarget.owner.cargo.{$supplyTarget.ware}.target == 0)))">
 												<set_value name="$needFound" exact="true" />
 												<create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$cargoHauled" immediate="false" />

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -274,7 +274,6 @@
 
 											<!--$cargoHauled == $targetAmount means it is the last few units needed to finish a station or drones-->
 											<set_value name="$cargoHauled" exact="[this.ship.cargo.{$supplyTarget.ware}.free,$targetAmount,$supplySource.amount].min" />
-											<set_value name="$tradeThis" exact="$cargoHauled gt 0 and ($allowLowVol or $cargoHauled gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($cargoHauled == $targetAmount and ($supplyTarget.owner.class == class.buildstorage or $supplyTarget.owner.cargo.{$supplyTarget.ware}.target == 0)))"/>
 											<do_if value="$cargoHauled gt 0 and ($allowLowVol or $cargoHauled gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($cargoHauled == $targetAmount and ($supplyTarget.owner.class == class.buildstorage or $supplyTarget.owner.cargo.{$supplyTarget.ware}.target == 0)))">
 												<set_value name="$needFound" exact="true" />
 												<create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$cargoHauled" immediate="false" />


### PR DESCRIPTION
Fixed issue where station mule thought that a factory was a warehouse instead of a production facility for final product wares (hull parts, claytronics, etc.). This was addressed by checking the products attribute of the station for the ware, as well as the tradewares attribute. 