### PR TITLE
Exempt Mules from station AutoTrade assignment

### DIFF
--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -60,7 +60,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/lib.request.orders.xml
+++ b/aiscripts/lib.request.orders.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+Whenever a ship tries to obtain "initial" orders...
+1. Because it has just been freshly constructed (NOT OUR MAIN POINT)
+2. Because it has just received a new assignment
+Do:
+1. Check if it is a ship-to-station assignment (passively checked as a result of original code structure)
+2. Check if it is running one of our Mules command
+3. If [2] returns true, protect the Mules and exempt them from getting the station assignment AutoTrade.
+Note:
+Requires the MD file in the other folder to work properly.
+Effect:
+Now possible to assign Mules to station with assignment="assignment.trade" while still retaining the Mules order.
+-->
+<diff>
+    <!-- Ship is now assigned to station. -->
+    <!-- pos="prepend" inserts XML nodes as the 1st child node of the given node. -->
+    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif" pos="prepend">
+        <!-- Check if the ship is running our Mules command -->
+        <!--
+            One-liner explanation:
+            $commander: the station; unused, but used to explain:
+            $object: the ship; could be running a Mule
+            $object.defaultorder.id: the id of the default order; e.g. if $object is running DistriMule, this property will be 'DistriMule' 
+                                     as per the id attribute from /aiscripts/distrib_mule.xml
+            {$list}.indexof.{$value}: returns true if value exists in the list, 0 otherwise
+            
+            In X4, a non-zero value will be evaluated to be TRUE.
+
+            Overall, this has the effect of checking if the ship is running our Mules command
+        -->
+        <do_if value="global.$mwex_AllMulesCommandTags.indexof.{$object.defaultorder.id}">
+            <set_value name="$flag_mwex_shipismule" exact="false" comment="Actual value not important; we simply need this variable to be here" />
+        </do_if>
+    </add>
+
+    <!-- Ship is now about to be given the AutoTrade script -->
+    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif/do_elseif" pos="before">
+        <!--
+            This position is just below Mining Assignment, and right above Trading Assignment.
+            It is convenient that there is only 1 do_elseif in the entire block of code describing what to do when there is a ship-to-station assignment
+            And that this do_elseif is exactly what we want.
+        -->
+        <!--
+            {$value}? checks if any variable with this name exists;
+            here, if we detected the ship running a Mules command, this variable will be here, and so the expression will be TRUE -->
+        <do_elseif value="$flag_mwex_shipismule?" comment="Our inaction here blocks the vanilla AutoTrade behavior from being applied.">
+            <debug_text text="'%1 (%2) is using one of the Mules script, and is now exempted from the AutoTrade assignment.'.[$object.knownname, $object]" chance="$debugchance" />
+        </do_elseif>
+    </add>
+</diff>

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -55,7 +55,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -57,7 +57,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="$sourceStation and ($sourceStation.owner == this.ship.owner) and $assignSrc">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -67,7 +67,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/md/mwex_setup.xml
+++ b/md/mwex_setup.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mdscript name="MulesAndWarehousesExtended_Setup" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="md.xsd">
+  <cues>
+    <cue name="MWEX_SettingUp" instantiate="true" version="2">
+      <conditions>
+        <event_cue_signalled cue="md.Setup.Start" />
+      </conditions>
+      <actions>
+        <!-- Safety -->
+        <remove_value name="global.$mwex_AllMulesCommandTags"/>
+
+        <!-- Setting the list -->
+        <set_value name="global.$mwex_AllMulesCommandTags" exact="[]" />
+
+        <!--
+          This list stores all the default behavior IDs of the many Mules. Change the values here when necessary.
+          The list is then used to protect the Mules from losing their orders when assigned to stations.
+          Combining with mods such as Subordinate Order Access https://www.nexusmods.com/x4foundations/mods/289
+          it is possible to modify the orders of the Mules even after station assignment.
+        -->
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'SupplyMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'TravelMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'StationMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'DistriMule'" />
+
+        <!-- Setup complete. -->
+      </actions>
+    </cue>
+  </cues>
+</mdscript>


### PR DESCRIPTION
Now possible to assign Mules with assignment=trade while retaining the Mules order

Earlier in #11 I mentioned "some extra script" is required to handle cases where Mules are assigned to stations but their Mules order have to be retained. This is the extra script that I have in mind: to exempt the Mules from receiving the AutoTrade default behavior. With these scripts in place, it is now possible to programmatically assign Mules to stations using assignment="assignment.trade" to make them appear in the trader group while still letting the Mules to carry on with their original Mule tasks.

By also using mods such as Subordinate Order Access https://www.nexusmods.com/x4foundations/mods/289 I believe it is possible to modify the parameters of the Mules even after station assignment, so it is quite promising.

 Consider this a jump-start to solving the trader role problem.