### PR TITLE
Fix ambiguous patch target of Mules exemption

### DIFF
--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -60,7 +60,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -39,7 +39,9 @@
 			</param>
 		</params>
 		<requires>
-			<match shiptype="shiptype.lasertower" negate="true" /> <!-- no idea wtf this is for-->
+			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+			<match shiptype="shiptype.lasertower" negate="true" />
 		</requires>
 	</order>
 

--- a/aiscripts/lib.request.orders.xml
+++ b/aiscripts/lib.request.orders.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+Whenever a ship tries to obtain "initial" orders...
+1. Because it has just been freshly constructed (NOT OUR MAIN POINT)
+2. Because it has just received a new assignment
+Do:
+1. Check if it is a ship-to-station assignment (passively checked as a result of original code structure)
+2. Check if it is running one of our Mules command
+3. If [2] returns true, protect the Mules and exempt them from getting the station assignment AutoTrade.
+Note:
+Requires the MD file in the other folder to work properly.
+Effect:
+Now possible to assign Mules to station with assignment="assignment.trade" while still retaining the Mules order.
+-->
+<diff>
+    <!-- Ship is now assigned to station. -->
+    <!-- pos="prepend" inserts XML nodes as the 1st child node of the given node. -->
+    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif" pos="prepend">
+        <!-- Check if the ship is running our Mules command -->
+        <!--
+            One-liner explanation:
+            $commander: the station; unused, but used to explain:
+            $object: the ship; could be running a Mule
+            $object.defaultorder.id: the id of the default order; e.g. if $object is running DistriMule, this property will be 'DistriMule' 
+                                     as per the id attribute from /aiscripts/distrib_mule.xml
+            {$list}.indexof.{$value}: returns true if value exists in the list, 0 otherwise
+            
+            In X4, a non-zero value will be evaluated to be TRUE.
+
+            Overall, this has the effect of checking if the ship is running our Mules command
+        -->
+        <do_if value="global.$mwex_AllMulesCommandTags.indexof.{$object.defaultorder.id}">
+            <set_value name="$flag_mwex_shipismule" exact="false" comment="Actual value not important; we simply need this variable to be here" />
+        </do_if>
+    </add>
+
+    <!-- Ship is now about to be given the AutoTrade script -->
+    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif/do_elseif" pos="before">
+        <!--
+            This position is just below Mining Assignment, and right above Trading Assignment.
+            It is convenient that there is only 1 do_elseif in the entire block of code describing what to do when there is a ship-to-station assignment
+            And that this do_elseif is exactly what we want.
+        -->
+        <!--
+            {$value}? checks if any variable with this name exists;
+            here, if we detected the ship running a Mules command, this variable will be here, and so the expression will be TRUE -->
+        <do_elseif value="$flag_mwex_shipismule?" comment="Our inaction here blocks the vanilla AutoTrade behavior from being applied.">
+            <debug_text text="'%1 (%2) is using one of the Mules script, and is now exempted from the AutoTrade assignment.'.[$object.knownname, $object]" chance="$debugchance" />
+        </do_elseif>
+    </add>
+</diff>

--- a/aiscripts/lib.request.orders.xml
+++ b/aiscripts/lib.request.orders.xml
@@ -34,16 +34,15 @@ Now possible to assign Mules to station with assignment="assignment.trade" while
         </do_if>
     </add>
 
-    <!-- Ship is now about to be given the AutoTrade script -->
-    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif/do_elseif" pos="before">
-        <!--
-            This position is just below Mining Assignment, and right above Trading Assignment.
-            It is convenient that there is only 1 do_elseif in the entire block of code describing what to do when there is a ship-to-station assignment
-            And that this do_elseif is exactly what we want.
-        -->
+    <!-- It is known that the ship is assigned to a certain station; game is now deciding what orders to give. -->
+    <!-- Inserting as the first do_elseif in decision making so to exempt the Mules; -->
+    <!-- Mules will enter the following custom block of code instead of the vanilla AutoTrade code further down below. -->
+    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_elseif/do_elseif[0]" pos="before">
         <!--
             {$value}? checks if any variable with this name exists;
-            here, if we detected the ship running a Mules command, this variable will be here, and so the expression will be TRUE -->
+            here, if we detected the ship running a Mules command, this variable will be here, and so the expression will be TRUE.
+            This detects the presence of Mules.
+        -->
         <do_elseif value="$flag_mwex_shipismule?" comment="Our inaction here blocks the vanilla AutoTrade behavior from being applied.">
             <debug_text text="'%1 (%2) is using one of the Mules script, and is now exempted from the AutoTrade assignment.'.[$object.knownname, $object]" chance="$debugchance" />
         </do_elseif>

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -35,7 +35,9 @@
 			<param name="allowCreateTrade" type="bool" default="false" text="Make Target Warehouse" comment="Allow mules to force Target to buy all the Source sells." />
 		</params>
 		<requires>
-			<match shiptype="shiptype.lasertower" negate="true" /> <!-- no idea wtf this is for-->
+			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+			<match shiptype="shiptype.lasertower" negate="true" />
 		</requires>
 	</order>
 

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -55,7 +55,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -57,7 +57,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="$sourceStation and ($sourceStation.owner == this.ship.owner) and $assignSrc">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -36,7 +36,9 @@
 			</param>
 		</params>
 		<requires>
-			<match shiptype="shiptype.lasertower" negate="true" /> <!-- no idea wtf this is for-->
+			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+			<match shiptype="shiptype.lasertower" negate="true" />
 		</requires>
 	</order>
 

--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -67,7 +67,7 @@
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner)">
-			<set_object_commander object="this.ship" commander="$sourceStation" />
+			<set_object_commander object="this.ship" commander="$sourceStation"  assignment="assignment.trade" />
 		</do_if>
 	</init>
 

--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -46,7 +46,9 @@
 			</param>
 		</params>
 		<requires>
-			<match shiptype="shiptype.lasertower" negate="true" /> <!-- no idea wtf this is for -->
+			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+			<match shiptype="shiptype.lasertower" negate="true" />
 		</requires>
 	</order>
 

--- a/md/mwex_setup.xml
+++ b/md/mwex_setup.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mdscript name="MulesAndWarehousesExtended_Setup" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="md.xsd">
+  <cues>
+    <cue name="MWEX_SettingUp" instantiate="true" version="2">
+      <conditions>
+        <event_cue_signalled cue="md.Setup.Start" />
+      </conditions>
+      <actions>
+        <!-- Safety -->
+        <remove_value name="global.$mwex_AllMulesCommandTags"/>
+
+        <!-- Setting the list -->
+        <set_value name="global.$mwex_AllMulesCommandTags" exact="[]" />
+
+        <!--
+          This list stores all the default behavior IDs of the many Mules. Change the values here when necessary.
+          The list is then used to protect the Mules from losing their orders when assigned to stations.
+          Combining with mods such as Subordinate Order Access https://www.nexusmods.com/x4foundations/mods/289
+          it is possible to modify the orders of the Mules even after station assignment.
+        -->
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'SupplyMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'TravelMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'StationMule'" />
+        <append_to_list name="global.$mwex_AllMulesCommandTags" exact="'DistriMule'" />
+
+        <!-- Setup complete. -->
+      </actions>
+    </cue>
+  </cues>
+</mdscript>


### PR DESCRIPTION
Follow-up patch of #22, where the previous patch-code was found to be too ambiguous.

Bonus commit content includes comment for the `requires` node of the four Mules.