### PR TITLE
fixes issue with travel mule wareBasket

### DIFF
--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -21,7 +21,8 @@
 				<input_param name="max" value="100" />
 				<input_param name="step" value="5" />
 			</param>
-
+			<!-- lock wares to player selection -->
+			<param name="lockWares" type="bool" default="false" text="Lock Wares to User Selection" comment="Locks the Users ware selection, otherwise we need to wipe it each time we call the script" />
 			<!-- menu option: WareBasket List -->
 			<param name="specialWareBasket" required="false" default="[]" type="list" text="Wares (all by default)" comment="Which Wares to consider in the trade.">
 				<input_param name="type" value="'ware'" />
@@ -71,12 +72,13 @@
 		<do_if value="($sourceStation.owner == this.ship.owner)">
 			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
 		</do_if>
+		<set_value name="$debugFileName" exact="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" />
 	</init>
 
 	<attention min="unknown">
 		<actions>
 			<label name="start" />
-			<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'Starting Log File'" output="false" append="false" />
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'Starting Log File'" output="false" append="false" />
 
 			<set_value name="$needFound" exact="false" />
 			<set_value name="$supplyTarget" exact="0" />
@@ -103,7 +105,7 @@
 
 				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
 				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
+				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
 
 				<do_all exact="5" counter="$reduction">
 					<!-- searching suiting buy offer, will search 5 times reducing requirements each time by 20% (just want to get rid of that stuff at some point) -->
@@ -126,21 +128,21 @@
 					<wait min="50ms" max="150ms" />
 
 					<do_if value="$buyOffer == null">
-						<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates :'+($maxSell+$reduction-1)" />
+						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates :'+($maxSell+$reduction-1)" />
 						<continue />
 					</do_if>
 
 					<set_value name="$amount" exact="[$amount,$buyOffer.amount].min" />
 
-					<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
+					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
 
 					<do_if value="$buyOffer.available">
 						<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" money="$buyOffer.unitprice*$amount" text="'Selling '+$amount+' '+$currentWare+', unitprice: '+$buyOffer.unitprice/100" />
 						<create_trade_order object="this.ship" amount="$amount" tradeoffer="$buyOffer" />
-						<debug_to_file name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'  trade created'" />
+						<debug_to_file name="$debugFileName" directory="'MulesExtended'" text="'  trade created'" />
 						<resume label="end" />
 					</do_if>
-					<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'  offer not available anymore'" />
+					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  offer not available anymore'" />
 				</do_all>
 				<show_notification text="['TravelMule: '+this.ship.knownname+' ('+this.ship.idcode+')', '', 'can\'t empty cargo', [$amount+' '+$currentWare, 255, 192, 126]]" sound="notification_warning" />
 				<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'can\'t get rid of '+$amount+' '+$currentWare+' from cargo, what should I do?'" />
@@ -150,20 +152,31 @@
 			<remove_value name="$buyOffer" />
 
 			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10)">
-				<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'TravelMule'" text="'  cargo is full =('" />
+				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'TravelMule'" text="'  cargo is full =('" />
 				<wait min="50ms" max="150ms" />
 				<resume label="start" />
 			</do_if>
 
-			<set_value name="$wareBasket" exact="$specialWareBasket" />
-			<do_if value="$wareBasket == []">
+			<!-- the previous mules method stops the issue where user input wares are overwritten, but the side effect is that the user
+			can't see the warebasket selected by the mule, which I think is very important for the user to understand what
+			the mule is doing. My solution is to add a checkbox to lock the user wares, then populate the UI variable
+			with the wareBasket the mule finds from searching for offers -->
+			<do_if value="(not $lockWares)">
+				<set_value name="$wareBasket" exact="[]" />
 				<do_if value="$sourceStation.tradewares.count">
-					<set_value name="$wareBasket" exact="$sourceStation.tradewares.list" />
+					<append_list_elements name="$wareBasket" other="$sourceStation.tradewares.list" />
 				</do_if>
-				<do_elseif value="$sourceStation.products.count">
-					<set_value name="$wareBasket" exact="$sourceStation.products.list" />
-				</do_elseif>
+				<do_if value="$sourceStation.products.count">
+					<append_list_elements name="$wareBasket" other="$sourceStation.products.list" />
+				</do_if>
+				<do_if value="$wareBasket.count">
+					<remove_from_list name="$specialWareBasket" />
+					<append_list_elements name="$specialWareBasket" other="$wareBasket" />
+				</do_if>
 			</do_if>
+			<do_else>
+				<set_value name="$wareBasket" exact="$specialWareBasket" />
+			</do_else>
 
 			<!-- technically sourceStation could be owned by someone on the blacklist, but the player picked this manually -->
 			<find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" wares="$wareBasket" multiple="true">
@@ -181,7 +194,7 @@
 				</match_seller>
 			</find_sell_offer>
 
-			<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'supplies: ' +$supplies" output="false" append="true" />
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'supplies: ' +$supplies" output="false" append="true" />
 
 
 			<!-- TODO: refactor these blocks -->
@@ -289,8 +302,8 @@
 						</do_all>
 					</do_all>
 				</do_else>
-				<!-- <debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'needs: ' +$needs" output="false" append="true" /> -->
-				<!-- <do_all exact="$needs.count" counter="$i"> <debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="' ' +$needs.{$i}.ware + ' ' +$needs.{$i}.owner.knownname" output="false" append="true" /> </do_all> -->
+				<!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'needs: ' +$needs" output="false" append="true" /> -->
+				<!-- <do_all exact="$needs.count" counter="$i"> <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="' ' +$needs.{$i}.ware + ' ' +$needs.{$i}.owner.knownname" output="false" append="true" /> </do_all> -->
 			</do_if>
 
 			<do_else>
@@ -337,13 +350,13 @@
 								</do_else>
 								<set_value name="$cargoHauled" exact="[this.ship.cargo.{$someInner.ware}.free,$targetAmount,$someOuter.amount].min" />
 								<set_value name="$currentProfit" exact="$cargoHauled * ($someInner.unitprice - $someOuter.unitprice*$profitMargin/100)" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'----'" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'cargoHauled: ' +$cargoHauled" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'buyer.unitprice: ' +$someInner.unitprice" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'seller.unitprice: ' +$someOuter.unitprice" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'currentProfit: ' +$currentProfit" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'bestProfit: ' +$bestProfit" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'this.ship.cargo.ware.max div 1.25: ' +this.ship.cargo.{$someInner.ware}.max / 1.25" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'----'" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'cargoHauled: ' +$cargoHauled" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'buyer.unitprice: ' +$someInner.unitprice" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'seller.unitprice: ' +$someOuter.unitprice" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'currentProfit: ' +$currentProfit" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'bestProfit: ' +$bestProfit" output="false" append="true" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'this.ship.cargo.ware.max div 1.25: ' +this.ship.cargo.{$someInner.ware}.max / 1.25" output="false" append="true" />
 
 								<do_if value="($currentProfit gt $bestProfit) and ($cargoHauled/(this.ship.cargo.{$someInner.ware}.max)) gt $minCargoUsed/100">
 									<set_value name="$supplyTarget" exact="$someInner" />
@@ -355,7 +368,7 @@
 								</do_if>
 							</do_if> <!-- need found -->
 						</do_all>
-						<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'need found: ' +$needFound" output="false" append="true" />
+						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'need found: ' +$needFound" output="false" append="true" />
 
 
 						<do_if value="$needFound">
@@ -364,7 +377,7 @@
 								<write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
 
 								<!-- Debug: Print profit stats to logfile -->
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
 
 							</do_if>
 							<do_else>
@@ -372,7 +385,7 @@
 								<write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
 
 								<!-- Debug: Print profit stats to logfile -->
-								<debug_to_file chance="$debugchance" name="'travelmule- ' + this.ship.knownname + ' ' + this.ship.idcode" directory="'MulesExtended'" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
+								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100 + ' for a profit of ' +$currentProfit/100" />
 
 							</do_else>
 


### PR DESCRIPTION
Travel Mule would first set the warebasket to all tradewares, then to all products. This may have been intentional, so that on a factory, wares needed for production weren't sold away. However, I've gone ahead and added both tradewares and products to the wareBasket, and also cleaned it up so that the auto-selected wares are displayed in the UI for the player to see what's going on.