### PR TITLE
Bugfix/supply mule.miner mule

### DIFF
--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -341,7 +341,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -557,7 +558,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -798,7 +800,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1053,7 +1056,8 @@
 										<get_ware_reservation object="$someSupply.owner" type="sell" ware="$someSupply.ware" result="$supplyReservations" />
 										<set_value name="$affordableAmount" exact="[$someSupply.amount-$supplyReservations,0].max" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1289,7 +1293,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1543,7 +1548,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1723,7 +1729,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1934,7 +1941,7 @@
 										<!-- The actual buying is done using the stations account (egosofts implementation as of 02.05.2020), when ordering your own ships that are assigned to the station or stations buildstorage -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2172,7 +2179,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2422,7 +2430,8 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2656,7 +2665,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2906,7 +2916,8 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3094,7 +3105,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3309,7 +3321,8 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3545,7 +3558,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3800,7 +3814,8 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4034,7 +4049,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4288,7 +4304,8 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4485,7 +4502,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4688,7 +4706,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4877,7 +4896,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -5081,7 +5101,8 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-($OccupiedCargo)f/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -336,14 +336,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<!-- however, if the trade will finish off the build storage for that good, do it anyway -->
@@ -361,7 +362,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -395,7 +396,7 @@
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -411,12 +412,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -553,14 +549,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<!-- however, if the trade will finish off the build storage for that good, let it through -->
@@ -577,7 +574,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -609,7 +606,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -625,12 +622,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -794,14 +786,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -814,7 +807,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -846,7 +839,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -862,12 +855,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -1049,14 +1037,17 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<get_ware_reservation object="$someSupply.owner" type="sell" ware="$someSupply.ware" result="$supplyReservations" />
+										<set_value name="$affordableAmount" exact="[$someSupply.amount-$supplyReservations,0].max" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -1069,7 +1060,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -1101,7 +1092,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1117,12 +1108,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -1286,14 +1272,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -1306,7 +1293,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -1338,7 +1325,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1354,12 +1341,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -1541,14 +1523,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -1561,7 +1544,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -1593,7 +1576,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1609,12 +1592,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -1722,14 +1700,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<!-- however, if the trade will finish off the build storage for that good, do it anyway -->
@@ -1746,7 +1725,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -1778,7 +1757,7 @@
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1796,12 +1775,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -1930,7 +1904,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station (not build storage) afford/store? -->
 										<!-- This is required because we issue a trade order using the ship, which only interacts with the stations account. -->
@@ -1991,7 +1966,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2007,12 +1982,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -2176,14 +2146,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -2196,7 +2167,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -2228,7 +2199,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2244,12 +2215,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -2426,7 +2392,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
@@ -2480,7 +2447,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2496,12 +2463,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -2665,14 +2627,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -2685,7 +2648,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -2717,7 +2680,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2733,12 +2696,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -2915,7 +2873,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
@@ -2923,7 +2882,7 @@
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -2969,7 +2928,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2985,12 +2944,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -3108,14 +3062,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<!-- however, if the trade will finish off the build storage for that good, do it anyway -->
@@ -3132,7 +3087,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -3166,7 +3121,7 @@
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3182,12 +3137,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -3323,7 +3273,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
@@ -3380,7 +3331,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3396,12 +3347,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -3564,14 +3510,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -3584,7 +3531,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -3616,7 +3563,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3632,12 +3579,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -3819,7 +3761,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
@@ -3873,7 +3816,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3889,12 +3832,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4058,14 +3996,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -4078,7 +4017,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -4109,7 +4048,7 @@
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4125,12 +4064,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4312,7 +4246,8 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
@@ -4366,7 +4301,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4382,12 +4317,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4513,14 +4443,16 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
+
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -4533,7 +4465,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -4567,7 +4499,7 @@
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4583,12 +4515,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4605,7 +4532,7 @@
 
 				<!-- ************************ buy from anyone, sell to AI station ************************** -->
 				<do_if value="(not $tradeWithOwn)">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----- ai to station build storage'" />
+					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----- ai to station general needs'" />
 
 					<!-- finding the station needs -->
 					<find_buy_offer space="player.galaxy" buyer="$sourceStation" tradepartner="this.ship" result="$stationNeeds" multiple="true"></find_buy_offer>
@@ -4717,14 +4644,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -4737,7 +4665,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -4769,7 +4697,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4785,12 +4713,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4906,14 +4829,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -4926,7 +4850,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -4960,7 +4884,7 @@
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4976,12 +4900,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>
@@ -4997,8 +4916,8 @@
 				</do_if> <!-- end of player to ai sector-->
 
 				<!-- ************************ buy from anyone, sell in sector of AI station ************************** -->
-				<do_if value="(not $dedicatedServe)">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----- ai to station build storage'" />
+				<do_if value="(not $dedicatedServe) and (not $tradeWithOwn)">
+					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----- ai to same sector as station'" />
 
 					<!-- finding the station needs -->
 					<find_buy_offer space="$sourceStation.sector" tradepartner="this.ship" result="$sectorNeeds" multiple="true"></find_buy_offer>
@@ -5028,7 +4947,7 @@
 					<do_if value="($sectorNeeds.count > 0) and (not $lockWares)">
 						<remove_from_list name="$specialWareBasket" />
 						<do_all exact="$stationNeeds.count" counter="$i">
-							<append_to_list name="$specialWareBasket" exact="$stationNeeds.{$i}.ware" />
+							<append_to_list name="$specialWareBasket" exact="$sectorNeeds.{$i}.ware" />
 						</do_all>
 					</do_if>
 
@@ -5110,14 +5029,15 @@
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$someNeed.offeramount" />
+										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
+										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
 										<!-- how much does the supply have to offer? -->
-										<set_value name="$supplyAmount" exact="$someSupply.amount" />
+										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
 										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$supplyAmount,$cargoHauled].min" />
+										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
 										<!-- if the trade is too small, move on -->
 										<do_if value="$tradeAmount*$someNeed.ware.volume lt $minCargoSize">
@@ -5130,7 +5050,7 @@
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
 												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$supplyAmount
+												+ ' supply amount: ' +$affordableAmount
 												+ ' ship can hold: ' +$cargoHauled
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
@@ -5162,7 +5082,7 @@
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" />
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -5178,12 +5098,7 @@
 							</do_if>
 						</do_all>
 
-						<!-- if we had more than one order we need to move the sell orders to the end -->
-						<do_all exact="this.ship.orders.count" counter="$i">
-							<do_if value="($i gt 1) and (($i % 2) gt 0)">
-								<move_order order="this.ship.orders.{$i}" newindex="1" />
-							</do_if>
-						</do_all>
+
 						<do_if value="this.ship.orders.count gt 0">
 							<resume label="end" />
 						</do_if>

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -341,7 +341,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -554,7 +554,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -791,7 +791,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1044,7 +1044,7 @@
 										<get_ware_reservation object="$someSupply.owner" type="sell" ware="$someSupply.ware" result="$supplyReservations" />
 										<set_value name="$affordableAmount" exact="[$someSupply.amount-$supplyReservations,0].max" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1277,7 +1277,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1528,7 +1528,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1705,7 +1705,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1913,7 +1913,7 @@
 										<!-- The actual buying is done using the stations account (egosofts implementation as of 02.05.2020), when ordering your own ships that are assigned to the station or stations buildstorage -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2151,7 +2151,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2398,7 +2398,7 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2632,7 +2632,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2879,7 +2879,7 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3067,7 +3067,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3279,7 +3279,7 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3515,7 +3515,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3767,7 +3767,7 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4001,7 +4001,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4252,7 +4252,7 @@
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4449,7 +4449,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4649,7 +4649,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4834,7 +4834,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -5034,7 +5034,7 @@
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.capacity.container-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -65,12 +65,12 @@
 	</interrupts>
 
 	<init>
-	<!-- debug settings -->
+		<!-- debug settings -->
 		<set_value name="$debugchance" exact="100" />
-		<set_value name="$debugFileName" exact="'SupplyMule - ' + this.ship.idcode"/>
-		<set_value name="$debugDirName" exact="'MulesExtended'"/>
+		<set_value name="$debugFileName" exact="'SupplyMule - ' + this.ship.idcode" />
+		<set_value name="$debugDirName" exact="'MulesExtended'" />
 		<!-- init section for mule script -->
-		<set_value name="$logbookEntryTitle" exact="'SupplyMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'"/>
+		<set_value name="$logbookEntryTitle" exact="'SupplyMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" />
 		<set_value name="$object" exact="this.assignedcontrolled" />
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
@@ -104,7 +104,7 @@
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    specialWareBasket: %1'.[$specialWareBasket]" output="false" append="true" />
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    playerBuyMod: %1'.[$playerBuyMod]" output="false" append="true" />
 			</do_if>
-			
+
 			<do_if value="$dedicatedServe and not $sourceStation">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Invalid Config: dedicatedServe (No Station configured)'" output="false" append="true" />
 				<set_value name="$dedicatedServe" exact="false" />
@@ -205,9 +205,9 @@
 				<!-- if we got to this point without finding a buyer, we're just going to dump the ware -->
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  had to drop %1 of %2'.[$amount,$currentWare]" />
 				<write_to_logbook category="general" title="$logbookEntryTitle" interaction="showonmap" object="this.ship" text="'had to drop %1 of %2 due to no buyers'.[$amount,$currentWare]" />
-				<drop_cargo object="this.ship" ware="$currentWare"  exact="$amount"/>
+				<drop_cargo object="this.ship" ware="$currentWare" exact="$amount" />
 			</do_all>
-			
+
 			<remove_value name="$searchStep" />
 			<remove_value name="$cargo" />
 			<remove_value name="$buyOffer" />
@@ -395,12 +395,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'}" />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -609,12 +609,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -846,12 +846,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1103,12 +1103,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1340,12 +1340,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1595,12 +1595,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1632,7 +1632,7 @@
 
 			</do_if> <!-- end of no $sourceStation if-->
 
-      <!-- ************************ case where station is set and owned by plaver ************************** -->
+			<!-- ************************ case where station is set and owned by plaver ************************** -->
 			<do_if value="$sourceStation and ($sourceStation.owner==this.ship.owner)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----- Source Station owned by Player block '" />
 
@@ -1780,12 +1780,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'}" />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -1989,12 +1989,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2171,6 +2171,9 @@
 									</do_if>
 
 									<!-- only do any work if the offers are for the same ware -->
+									<!-- I have seen this $someNeed.ware.id error before implying that something is null 
+										I can't figure out why it would error here but not in the debug list above. Makes me think
+										perhaps it's erroring because we've already filled the need and the order has disappeared completely-->
 									<do_if value="$someNeed.ware.id == $someSupply.ware.id">
 
 										<!-- how much does the need want? -->
@@ -2226,12 +2229,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2475,12 +2478,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2712,12 +2715,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -2961,12 +2964,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3158,12 +3161,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'}" />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3369,12 +3372,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.base.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3605,12 +3608,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -3859,12 +3862,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4096,11 +4099,11 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4349,12 +4352,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4386,7 +4389,7 @@
 
 			</do_if> <!-- end of $sourceStation if-->
 
-      <!-- ************************ case where station is set but not owned by plaver ************************** -->
+			<!-- ************************ case where station is set but not owned by plaver ************************** -->
 			<do_if value="($sourceStation) and ($sourceStation.owner != this.ship.owner)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Source Station set to ' +$sourceStation.knownname +' Entering Source Station owned by AI block'" />
 
@@ -4422,7 +4425,7 @@
 					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    ' 
 									+$stationNeeds.count + ' '
 									+$lockWares + ' '
-									+$specialWareBasket"/>
+									+$specialWareBasket" />
 					<do_if value="($stationNeeds.count > 0) and (not $lockWares)">
 						<remove_from_list name="$specialWareBasket" />
 						<do_all exact="$stationNeeds.count" counter="$i">
@@ -4551,12 +4554,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'}" />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4753,12 +4756,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -4946,12 +4949,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'}" />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 										+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 										+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>
@@ -5148,12 +5151,12 @@
 									<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +$bestSupplyTrade.unitprice.formatted.{'%s %Cr'} + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +$bestNeedTrade.unitprice.formatted.{'%s %Cr'} + ' for a profit of ' +$bestProfit.formatted.{'%s %Cr'} " />
-	
+
 									<write_to_logbook category="upkeep" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="'buying ' +$bestAmount + ' ' +$bestNeedTrade.ware +' from ' +$bestSupplyTrade.owner.knownname
 									+' at ' +($bestSupplyTrade.unitprice.formatted.{'%s %Cr'}) + ' to sell to ' +$bestNeedTrade.owner.knownname
 									+' at ' +($bestNeedTrade.unitprice.formatted.{'%s %Cr'}) + ' for a profit of ' +($bestProfit.formatted.{'%s %Cr'})" />
 
-									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+									<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount" immediate="true" />
 									<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 								</do_if>
 								<do_else>

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -337,11 +337,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -361,9 +361,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -550,11 +553,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -573,9 +576,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -787,11 +793,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
+
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -806,9 +813,11 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -1038,13 +1047,13 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 
 										<!-- how much does the supply have to offer? -->
 										<get_ware_reservation object="$someSupply.owner" type="sell" ware="$someSupply.ware" result="$supplyReservations" />
 										<set_value name="$affordableAmount" exact="[$someSupply.amount-$supplyReservations,0].max" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1059,9 +1068,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -1273,11 +1285,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1292,9 +1304,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -1524,11 +1539,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1543,9 +1558,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -1701,11 +1719,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -1724,9 +1742,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -1905,7 +1926,7 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station (not build storage) afford/store? -->
 										<!-- This is required because we issue a trade order using the ship, which only interacts with the stations account. -->
@@ -1913,7 +1934,7 @@
 										<!-- The actual buying is done using the stations account (egosofts implementation as of 02.05.2020), when ordering your own ships that are assigned to the station or stations buildstorage -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2147,11 +2168,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2166,9 +2187,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -2393,12 +2417,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2628,11 +2652,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -2647,9 +2671,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -2874,12 +2901,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3063,11 +3090,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3086,9 +3113,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -3274,12 +3304,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3511,11 +3541,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3530,9 +3560,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -3762,12 +3795,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -3997,11 +4030,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4016,9 +4049,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -4247,12 +4283,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.desiredamount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.desiredamount" />
 										<!-- how much does the supply have to offer? -->
 										<!-- how much can the station afford/store? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4444,12 +4480,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.amount" />
 
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4464,9 +4500,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -4645,11 +4684,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.amount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4662,11 +4701,14 @@
 										<!-- how much profit for this trade? -->
 										<set_value name="$currentProfit" exact="$cargoHauled * ($someNeed.unitprice - $someSupply.unitprice)" />
 
+
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -4830,11 +4872,12 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.amount" />
+
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -4847,11 +4890,15 @@
 										<!-- how much profit for this trade? -->
 										<set_value name="$currentProfit" exact="$cargoHauled * ($someNeed.unitprice - $someSupply.unitprice)" />
 
+
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice
@@ -5030,11 +5077,11 @@
 
 										<!-- how much does the need want? -->
 										<get_ware_reservation object="$someNeed.owner" type="buy" ware="$someNeed.ware" result="$needReservations" />
-										<set_value name="$targetOfferedAmount" exact="[$someNeed.amount-$needReservations,0].max" />
+										<set_value name="$targetOfferedAmount" exact="$someNeed.amount" />
 										<!-- how much does the supply have to offer? -->
 										<clamp_trade_amount trade="$someSupply" amount="$someSupply.amount" buyer="this.assignedcontrolled" seller="$someSupply.seller" result="$affordableAmount" />
 										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[((this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo)/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
+										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$someSupply.ware}.max-$OccupiedCargo/$someNeed.ware.volume)i, this.ship.cargo.{$someNeed.ware}.free].min" />
 
 										<!-- the amount for the trade is the minimum of the three amounts -->
 										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
@@ -5049,9 +5096,12 @@
 
 										<do_if value="$debugchance">
 											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$someNeed.ware
-												+ ' target desired amount ' +$targetOfferedAmount
-												+ ' supply amount: ' +$affordableAmount
-												+ ' ship can hold: ' +$cargoHauled
+												+ ' target desired amount ' +$someNeed.desiredamount
+												+ ' target amount ' +$someNeed.amount
+												+ ' target offeramount ' +$someNeed.offeramount
+												+ ' target reservations ' +$needReservations
+												+ ' offer amount - reservations ' +($someNeed.offeramount-$needReservations)
+												+ ' clamped amount: ' +$affordableAmount
 												+ ' amount will be: ' +$tradeAmount
 												+ ' need unitprice: ' +$someNeed.unitprice
 												+ ' supp unitprice: ' +$someSupply.unitprice


### PR DESCRIPTION
- fixed miner used as supply mule not finding valid trades
- reverted a change to calculating the amount that an order needs when buying from the player ship. Reservations were being counted twice in my testing.