### PR TITLE
Dev

### DIFF
--- a/aiscripts/mule.lib.debug.dump_tradeoffers.xml
+++ b/aiscripts/mule.lib.debug.dump_tradeoffers.xml
@@ -31,7 +31,7 @@
 						<do_else>
 							<set_value name="$buyerName" exact="$offer.buyer.knownname"/>
 						</do_else>
-						<set_value name="$debugText" exact="'%s%s (%s) wants to buy %s %s for %s (%s)\n'.[$debugText,$buyerName, $offer.buyer.idcode, $offer.amount, $offer.ware, $offer.unitprice, $offer.relativeprice]"/>
+						<set_value name="$debugText" exact="'%s%s (%s) wants to buy %s (desired %s, offer %s, stocklevel %s) %s for %s (%s)\n'.[$debugText,$buyerName, $offer.buyer.idcode, $offer.amount, $offer.desiredamount, $offer.offeramount, $offer.stocklevel, $offer.ware, $offer.unitprice, $offer.relativeprice]"/>
 					</do_else>
 				</do_for_each>
 				<debug_to_file name="$debugFileName" directory="$debugDirName" text="$debugText" />

--- a/aiscripts/mule.lib.evaluate_tradeoffers.xml
+++ b/aiscripts/mule.lib.evaluate_tradeoffers.xml
@@ -16,6 +16,8 @@
 		<param name="occupiedCargo"/>
 		<!-- minimum cargo size for allowed transport -->
 		<param name="minCargoSize"/>
+		<!-- use fill level for profit calculation instead of buy/sell price difference -->
+		<param name="dedicatedPlayerBuilder" />
 		<!-- enable/disable debug messages -->
 		<param name="debugchance"/>
 		<param name="debugFileName"/>
@@ -51,6 +53,10 @@
 				<remove_value name="$filteredBuyoffers"/>
 			</do_if>
 
+			<do_if value="$dedicatedPlayerBuilder" >
+				<!--randomize construction materials inside the same fill level region-->
+				<shuffle_list list="$buyoffers" />
+			</do_if>
 			<!-- nested loop(s) over the trade offers -->
 			<do_for_each name="$buyoffer" in="$buyoffers">
 				<do_for_each name="$selloffer" in="$selloffers">
@@ -130,13 +136,24 @@
 						<continue />
 					</do_if>
 
-					<!-- how much profit for this trade? -->
-					<!-- If we use our own stations, we adjust the supply price by the sameFactionBuyMod to allow preferential treatment of player/owned supply chains -->
-					<do_if value="$selloffer.seller.owner == $shipEntity.owner">
-						<set_value name="$currentProfit" exact="$cargoHauled * ($buyoffer.unitprice - $selloffer.unitprice*$sameFactionBuyMod/100.0)" />
+					<do_if value="$dedicatedPlayerBuilder" >
+						<set_value name="$targetAmount" exact="$buyoffer.buyer.cargo.{$buyoffer.ware}.target" />
+						<!--calculate fill level region: 0%..33% = 3; 33%..67% = 2; 67%..100% = 1 -->
+						<!--REMIND (don't optimize) desired amount / target amount equals to the stock level when the construction is fully funded only-->
+						<set_value name="$fillLevelRegion" exact="((($buyoffer.desiredamount)f / ([$targetAmount,1].max)f - 0.0000001) * 3.0 + 1.0)i" />
+						<set_value name="$currentProfit" exact="$fillLevelRegion * 1Cr" />
+						<remove_value name="$targetAmount" />
+						<remove_value name="$fillLevelRegion" />
 					</do_if>
 					<do_else>
-						<set_value name="$currentProfit" exact="$cargoHauled * ($buyoffer.unitprice - $selloffer.unitprice)" />
+						<!-- how much profit for this trade? -->
+						<!-- If we use our own stations, we adjust the supply price by the sameFactionBuyMod to allow preferential treatment of player/owned supply chains -->
+						<do_if value="$selloffer.seller.owner == $shipEntity.owner">
+							<set_value name="$currentProfit" exact="$cargoHauled * ($buyoffer.unitprice - $selloffer.unitprice*$sameFactionBuyMod/100.0)" />
+						</do_if>
+						<do_else>
+							<set_value name="$currentProfit" exact="$cargoHauled * ($buyoffer.unitprice - $selloffer.unitprice)" />
+						</do_else>
 					</do_else>
 
 					<do_if value="$debugchance">
@@ -159,6 +176,11 @@
 						<set_value name="$bestSupplyTrade" exact="$selloffer" />
 						<set_value name="$bestAmount" exact="$tradeAmount" />
 					</do_if>
+					<!--search for the best trade amount in the same fill level region between supply offers of the same ware-->
+					<do_elseif value="$dedicatedPlayerBuilder and ($currentProfit == $bestProfit) and ($tradeAmount > $bestAmount) and ($bestNeedTrade.ware.id == $buyoffer.ware.id)" >
+						<set_value name="$bestSupplyTrade" exact="$selloffer" />
+						<set_value name="$bestAmount" exact="$tradeAmount" />
+					</do_elseif>
 					<wait sinceversion="2" exact="1ms"/>
 				</do_for_each>
 			</do_for_each>

--- a/aiscripts/mule.lib.evaluate_tradeoffers.xml
+++ b/aiscripts/mule.lib.evaluate_tradeoffers.xml
@@ -109,7 +109,7 @@
 					</do_elseif>
 
 					<!-- how much does the need want? -->
-					<get_ware_reservation object="$buyoffer.owner" type="buy" ware="$buyoffer.ware" result="$needReservations" />
+					<!--<get_ware_reservation object="$buyoffer.owner" type="buy" ware="$buyoffer.ware" result="$needReservations" />-->
 					<set_value name="$targetOfferedAmount" exact="$buyoffer.desiredamount" />
 					<!-- how much does the supply have to offer? -->
 					<clamp_trade_amount trade="$selloffer" amount="$selloffer.amount" buyer="$shipEntity.assignedcontrolled" seller="$selloffer.seller" result="$affordableAmount" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -125,8 +125,9 @@
 		<actions>
 			<label name="start" />
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ScriptStart'" append="false"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'Entity (this): %s'.[this]"/>
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'AssignedControlled: %s (%s) - %s'.[this.assignedcontrolled.knownname, this.assignedcontrolled.idcode, this.assignedcontrolled]" />
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Entity (this): %s'.[this]"/>
 
 			<!-- Dump Mule Settings -->
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Supply Mule Settings:'"/>
@@ -182,7 +183,7 @@
 					</do_if>
 				</do_if>
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    copying default behavior'"/>
-				<remove_object_commander object="$subordinate" />
+<!--				<remove_object_commander object="$subordinate" />-->
 				<create_order object="$subordinate" default="true" id="'SupplyMule'">
 					<!-- Note: we changed the default orders, therefore civilian fleets needs an update -->
 					<param name="home" value="$home" />
@@ -291,7 +292,7 @@
    					serve player sector
    					serve player area
    			-->
-			<!-- Dedicated serve: only serve assigned home, weather its a station or sector -->
+			<!-- Dedicated serve: only serve assigned home, whether its a station or sector -->
 			<!-- Serve order: buildstorage -> resources -> intermediates -> tradewares -->
 
 			<!-- $supplierFactions: list of factions -->
@@ -301,11 +302,13 @@
 
 			<set_value name="$isServingStationOrShip" exact="if ($homeStationOrShip != null) then true else false"/>
 			<set_value name="$isServingSector" exact="if (($home.isclass.sector and $dedicatedServe) or ($home.isclass.{[class.ship, class.station]} and not $dedicatedServe)) then true else false"/>
-			<set_value name="$serveFactions" exact="if ($isServingStationOrShip and $homeStationOrShip.owner != faction.player) then $aiFactions else $playerFactions"/>
-			<set_value name="$isServingArea" exact="($serveFactions == $playerFactions) and (not $dedicatedServe)"/>	
+			<set_value name="$isServingPlayer" exact="(not $isServingStationOrShip) or ($homeStationOrShip.owner == faction.player)" />
+			<set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions else $aiFactions" />
+			<set_value name="$isServingArea" exact="$isServingPlayer and (not $dedicatedServe)" />
 
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingStationOrShip: %s'.[$isServingStationOrShip]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingSector: %s'.[$isServingSector]"/>
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingPlayer: %s'.[$isServingPlayer]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    serveFactions: %s'.[$serveFactions]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingArea: %s'.[$isServingArea]"/>
 
@@ -435,7 +438,7 @@
 					<create_list name="$filteredNeeds" />
 					<!-- Check for every need if it fullfills the requirement and add -->
 					<do_for_each chance="100*($needs.count > 0)" name="$need" in="$needs">
-						<set_value name="$isResource" exact="$need.owner.resources.{$need.ware}.exists"/>
+						<set_value name="$isResource" exact="$need.owner.resources.{$need.ware}.exists or $need.owner.supplyresources.{$need.ware}.exists"/>
 						<set_value name="$isProduct" exact="$need.owner.products.{$need.ware}.exists"/>
 						<!-- X4 treats products and resources always as tradewares... -->
 						<set_value name="$isWare" exact="$need.owner.tradewares.{$need.ware}.exists"/>
@@ -572,7 +575,7 @@
 						</do_if>
 
 						<do_if value="$bestSupplyTrade.available and $bestNeedTrade.available">
-							<set_value name="$tradeText" exact="'buying %s %s from %s (%s) at %s  to sell to %s (%s) at %s for a profit of'.[$bestAmount, $bestNeedTrade.ware, $bestSupplyTrade.owner.knownname, $bestSupplyTrade.owner.idcode, $bestSupplyTrade.unitprice.formatted.{'%s %Cr'}, $bestNeedTrade.owner.knownname, $bestNeedTrade.owner.idcode, $bestNeedTrade.unitprice.formatted.{'%s %Cr'}, $bestProfit.formatted.{'%s %Cr'}]"/>
+							<set_value name="$tradeText" exact="'buying %s %s from %s (%s) at %s  to sell to %s (%s) at %s for a profit of %s.'.[$bestAmount, $bestNeedTrade.ware, $bestSupplyTrade.owner.knownname, $bestSupplyTrade.owner.idcode, $bestSupplyTrade.unitprice.formatted.{'%s %Cr'}, $bestNeedTrade.owner.knownname, $bestNeedTrade.owner.idcode, $bestNeedTrade.unitprice.formatted.{'%s %Cr'}, $bestProfit.formatted.{'%s %Cr'}]"/>
 							<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$tradeText" />
 							<write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="$tradeText" />
 

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -294,6 +294,7 @@
    			-->
 			<!-- Dedicated serve: only serve assigned home, whether its a station or sector -->
 			<!-- Serve order: buildstorage -> resources -> intermediates -> tradewares -->
+			<!-- Dedicated player's builder mode. Activated by: * selected allow build storage only; * selected station or sector as home. When active - an evaluation of trade offers is perfomed by a fill level algorithm instead of a best profit. -->
 
 			<!-- $supplierFactions: list of factions -->
 			<!-- $serve: 'station', 'sector', 'area' -->
@@ -305,12 +306,14 @@
 			<set_value name="$isServingPlayer" exact="(not $isServingStationOrShip) or ($homeStationOrShip.owner == faction.player)" />
 			<set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions else $aiFactions" />
 			<set_value name="$isServingArea" exact="$isServingPlayer and (not $dedicatedServe)" />
+			<set_value name="$isDedicatedPlayerBuilder" exact="$isServingPlayer and $allowBuildstorage and (not $allowResources) and (not $allowIntermediates) and (not $allowTradewares)" />
 
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingStationOrShip: %s'.[$isServingStationOrShip]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingSector: %s'.[$isServingSector]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingPlayer: %s'.[$isServingPlayer]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    serveFactions: %s'.[$serveFactions]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingArea: %s'.[$isServingArea]"/>
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isDedicatedPlayerBuilder: %s'.[$isDedicatedPlayerBuilder]"/>
 
 			<do_if value="$isServingStationOrShip">
 				<!-- Serve Station -->
@@ -561,6 +564,7 @@
 							<param name="debugchance" value="$debugchance"/>
 							<param name="debugFileName" value="$debugFileName"/>
 							<param name="debugDirName" value="$debugDirName"/>
+							<param name="dedicatedPlayerBuilder" value="$isDedicatedPlayerBuilder" />
 							<save_retval name="bestProfit" variable="$bestProfit"/>
 							<save_retval name="bestAmount" variable="$bestAmount"/>
 							<save_retval name="bestNeedTrade" variable="$bestNeedTrade"/>


### PR DESCRIPTION
Supply mule receives a new player station builder mode. In this mode, filling the building storage with materials is smoother. To activate the mode, you need to choose allow the build storage only. Not used to supply NPC stations.