### PR TITLE
improve station mule supplyFirst logic

### DIFF
--- a/aiscripts/order.assist.xml
+++ b/aiscripts/order.assist.xml
@@ -17,6 +17,7 @@
             <param name="lockWares" value="$order.$lockWares"/>
             <param name="specialWareBasket" value="$order.$specialWareBasket"/>
             <param name="maxTrades" value="$order.$maxTrades"/>
+            <param name="minCargoUsed" value="$order.$minCargoUsed"/>
             <param name="playerBuyMod" value="$order.$playerBuyMod"/>
             <param name="restartScript" value="$order.$restartScript"/>
             <!-- don't copy deprecated params -->
@@ -38,6 +39,7 @@
             <param name="forbidTradeAll" value="$order.$forbidTradeAll"/>
             <param name="allowLowVol" value="$order.$allowLowVol"/>
             <param name="allowCreateTrade" value="$order.$allowCreateTrade"/>
+            <param name="restartScript" value="$order.$restartScript"/>
 		</run_script>
     </do_elseif>
     <do_elseif value="$order.id == 'TravelMule'">

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -273,9 +273,21 @@
 					<set_value name="$outerList" exact="[]" />
 					<!-- Sort Trades -->
 					<do_if value="$supplyFirstLocal">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority setting needs to innerList and supplies to outerList sorted by volume'" />
+						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority setting needs to innerList and supplies to outerList sorted by stocklevel descending'" />
 						<set_value name="$innerList" exact="$needs" />
-						<sort_trades name="$outerList" tradelist="$supplies" sorter="volume" />
+
+						<!-- shuffling due to advice in sort_trades docstring, and reversing list to sort descending -->
+						<shuffle_list list="$supplies" />
+						<sort_trades name="$dummyList" tradelist="$supplies" sorter="stocklevel" />
+
+						<set_value name="$outerList" exact="[]"/>
+						<do_all exact="$dummyList.count" counter="$dummy" reverse="true">
+							<append_to_list name="$outerList" exact="$dummyList.{$dummy}" />
+						</do_all>
+						<remove_value name="$dummyList" />
+						<do_all exact="$outerList.count" counter="$i">
+							<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' + $outerList.{$i}.ware + ' ' + $outerList.{$i}.volume + ' ' + $outerList.{$i}.stocklevel" />
+						</do_all>
 					</do_if>
 					<do_else>
 						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority not set, evaluating our own priorities '" />
@@ -419,10 +431,10 @@
 										<!-- X4 treats products and resources always as tradewares... -->
 										<set_value name="$sourceIsWare" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists"/>
 
-										<set_value name="$targetIsResourceOnly" exact="$targetIsResource and (not $targetIsProduct))"/>
-										<set_value name="$targetIsProductOnly" exact="$(not targetIsResource) and ($targetIsProduct))"/>
+										<set_value name="$targetIsResourceOnly" exact="$targetIsResource and (not $targetIsProduct)"/>
+										<set_value name="$targetIsProductOnly" exact="(not $targetIsResource) and $targetIsProduct"/>
 										<set_value name="$targetIsIntermediate" exact="$targetIsResource and $targetIsProduct"/>
-										<set_value name="$targetIsWareOnly" exact="$targetIsWare and (not $targetIsResource) and (not $targetIsProduct))"/>
+										<set_value name="$targetIsWareOnly" exact="$targetIsWare and (not $targetIsResource) and (not $targetIsProduct)"/>
 
 										<!-- this value is the amount of the trade / target amount. So 1-stocklevel is effectively the current stock level of the target -->
 										<set_value name="$targetStockLevel" exact="$supplyTarget.stocklevel" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<aiscript name="supplymule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="3">
+<aiscript name="supplymule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="4">
 	<!-- Setup context menu order-->
 	<order id="SupplyMule" name="M4- Supply Mule" description="Supplys own Stations Needs" category="trade" infinite="true">
 		<params>
@@ -59,6 +59,14 @@
 				<input_param name="max" value="1" />
 				<input_param name="step" value="1" />
 				<patch sinceversion="2" value="$maxtrades"/>
+			</param>
+
+			<param name="minCargoUsed" default="75" type="number" text="Fill Cargo Hold %" comment="The percentage of the ship's cargo hold that the trade will take up.">
+				<input_param name="startvalue" value="75" />
+				<input_param name="min" value="25" />
+				<input_param name="max" value="95" />
+				<input_param name="step" value="5" />
+				<patch sinceversion="4" value="75"/>
 			</param>
 
 			<!-- menu option: Profit Override Percentage (Used when buying/selling at own warehouses mostly) -->
@@ -149,6 +157,7 @@
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    lockWares: %s'.[$lockWares]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    specialWareBasket: %s'.[$specialWareBasket]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    maxTrades: %s'.[$maxTrades]"/>
+			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    minCargoUsed: %s'.[$minCargoUsed]"/>
 			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    playerBuyMod: %s'.[$playerBuyMod]"/>
 
 			<do_if value="$assignHome and $home.isclass.sector">
@@ -527,7 +536,7 @@
 					<set_value name="$ShipCapacity" exact="this.ship.cargo.capacity.all" />
 					<!-- by hacking the maxTrades to 1 we make the supply mule have some trouble finding trades, so we need to add some leniency 
 					until we can figure out a longer term solution.... which may be a cargo % slider? -->
-					<set_value name="$minCargoSize" exact="0.75*($ShipCapacity)f / $maxTrades" />
+					<set_value name="$minCargoSize" exact="($minCargoUsed/100.0)*($ShipCapacity)f / $maxTrades" />
 					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ship capacity: ' + $ShipCapacity" />
 
 					<!-- these lists will hold the trades we want to make. we'll check they're still available before creating the orders -->


### PR DESCRIPTION
* when using one of the "seller priority" or "return seller priority" options on station mule, the trades will be prioritized by descending stock level (i.e., for "seller priority", the highest stock percentage on the source station will be the first trade evaluated)
* added cargo hold pct slider on supply mule