### PR TITLE
Feature/cargo emptying

### DIFF
--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -1,291 +1,291 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <aiscript name="distrimule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="3">
-	<!-- Setup context menu order-->
-	<order id="DistriMule" name="{61552,3001}" description="{61552,3101}" category="trade" infinite="true">
-		<params>
-			<!-- menu option: Source Warehouse (Define Source Station)-->
-			<param name="sourceStation" required="false" default="null" type="object" text="{61552,3002}" comment="{61552,3102}">
-				<input_param name="class" value="[class.station]" />
-			</param>
-			<!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
-			<param name="assignSrc" type="bool" default="true" text="{61552,2004}" comment="{61552,2104}">
-				<patch sinceversion="2" value="true"/>
-			</param>
-			<!-- menu option: Min Storage-->
-			<param name="minStorage" required="false" default="20" type="number" text="{61552,3003}" comment="{61552,3103}">
-				<input_param name="startvalue" value="20" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="98" />
-				<input_param name="step" value="1" />
-			</param>
-			<!-- menu option: Static Storage-->
-			<param name="staticStorage" required="false" default="40" type="number" text="{61552,3004}" comment="{61552,3104}">
-				<input_param name="startvalue" value="40" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="99" />
-				<input_param name="step" value="1" />
-			</param>
-			<!-- menu option: Max Storage-->
-			<param name="maxStorage" required="false" default="70" type="number" text="{61552,3005}" comment="{61552,3105}">
-				<input_param name="startvalue" value="70" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="100" />
-				<input_param name="step" value="1" />
-			</param>
-			<!-- menu option: WareBasket list-->
-			<param name="specialWareBasket" required="false" default="[]" type="list" text="{61552,3006}" comment="{61552,3106}">
-				<input_param name="type" value="'ware'" />
-				<input_param name="cancarry" value="this.ship" />
-			</param>
-			<!-- menu option: Destination Override (select stations manually to visit)-->
-			<param name="destList" required="false" default="[]" type="list" text="{61552,3007}" comment="{61552,3107}">
-				<input_param name="type" value="'object'" />
-			</param>
-			<param name="restartScript" type="internal" default="false"/>
+    <!-- Setup context menu order-->
+    <order id="DistriMule" name="{61552,3001}" description="{61552,3101}" category="trade" infinite="true">
+        <params>
+            <!-- menu option: Source Warehouse (Define Source Station)-->
+            <param name="sourceStation" required="false" default="null" type="object" text="{61552,3002}" comment="{61552,3102}">
+                <input_param name="class" value="[class.station]" />
+            </param>
+            <!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
+            <param name="assignSrc" type="bool" default="true" text="{61552,2004}" comment="{61552,2104}">
+                <patch sinceversion="2" value="true"/>
+            </param>
+            <!-- menu option: Min Storage-->
+            <param name="minStorage" required="false" default="20" type="number" text="{61552,3003}" comment="{61552,3103}">
+                <input_param name="startvalue" value="20" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="98" />
+                <input_param name="step" value="1" />
+            </param>
+            <!-- menu option: Static Storage-->
+            <param name="staticStorage" required="false" default="40" type="number" text="{61552,3004}" comment="{61552,3104}">
+                <input_param name="startvalue" value="40" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="99" />
+                <input_param name="step" value="1" />
+            </param>
+            <!-- menu option: Max Storage-->
+            <param name="maxStorage" required="false" default="70" type="number" text="{61552,3005}" comment="{61552,3105}">
+                <input_param name="startvalue" value="70" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="100" />
+                <input_param name="step" value="1" />
+            </param>
+            <!-- menu option: WareBasket list-->
+            <param name="specialWareBasket" required="false" default="[]" type="list" text="{61552,3006}" comment="{61552,3106}">
+                <input_param name="type" value="'ware'" />
+                <input_param name="cancarry" value="this.ship" />
+            </param>
+            <!-- menu option: Destination Override (select stations manually to visit)-->
+            <param name="destList" required="false" default="[]" type="list" text="{61552,3007}" comment="{61552,3107}">
+                <input_param name="type" value="'object'" />
+            </param>
+            <param name="restartScript" type="internal" default="false"/>
 
-		</params>
-		<requires>
-			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
-			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
-			<match shiptype="shiptype.lasertower" negate="true" />
-		</requires>
-	</order>
+        </params>
+        <requires>
+            <!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+            <!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+            <match shiptype="shiptype.lasertower" negate="true" />
+        </requires>
+    </order>
 
-	<interrupts>
-		<handler ref="AttackHandler" />
-		<handler ref="MissileLockHandler" />
-		<handler ref="ScannedHandler" />
-		<handler ref="InspectedHandler" />
-		<handler ref="FoundAbandonedHandler" />
-		<handler ref="ResupplyHandler" />
-		<handler ref="JobRemoveRequestHandler" />
-		<handler ref="TargetInvalidHandler" />
-	</interrupts>
+    <interrupts>
+        <handler ref="AttackHandler" />
+        <handler ref="MissileLockHandler" />
+        <handler ref="ScannedHandler" />
+        <handler ref="InspectedHandler" />
+        <handler ref="FoundAbandonedHandler" />
+        <handler ref="ResupplyHandler" />
+        <handler ref="JobRemoveRequestHandler" />
+        <handler ref="TargetInvalidHandler" />
+    </interrupts>
 
-	<init>
-		<set_value name="$debugchance" exact="100" />
-		<set_value name="$debugFileName" exact="'DistribMule - ' + this.ship.idcode"/>
-		<set_value name="$debugDirName" exact="'MulesExtended'"/>
-		<set_value name="$object" exact="this.assignedcontrolled" />
-		<set_value name="$logbookEntryTitle" exact="'DistribMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
-		<set_order_syncpoint_reached order="this.ship.order" />
-		<set_command_action commandaction="commandaction.searchingtrades" />
-		<do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
-			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
-		</do_if>
-	</init>
+    <init>
+        <set_value name="$debugchance" exact="100" />
+        <set_value name="$debugFileName" exact="'DistribMule - ' + this.ship.idcode"/>
+        <set_value name="$debugDirName" exact="'MulesExtended'"/>
+        <set_value name="$object" exact="this.assignedcontrolled" />
+        <set_value name="$logbookEntryTitle" exact="'DistribMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
+        <set_order_syncpoint_reached order="this.ship.order" />
+        <set_command_action commandaction="commandaction.searchingtrades" />
+        <do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
+            <set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
+        </do_if>
+    </init>
 
-	<patch sinceversion="3">
-		<!-- This will reissue any standing supply mule orders -->
-		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
-		<debug_text text="'PATCH: Restarting distrib mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
-		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
-	</patch>
+    <patch sinceversion="3">
+        <!-- This will reissue any standing supply mule orders -->
+        <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+        <debug_text text="'PATCH: Restarting distrib mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
+        <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
+    </patch>
 
-	<attention min="unknown">
-		<actions>
-			<label name="start" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ScriptStart'" output="false" append="false" />
-			<set_value name="$needFound" exact="false" />
-			<set_value name="$needFound2" exact="false" />
-			<set_value name="$supplyTarget" exact="0" />
-			<set_value name="$supplySource" exact="0" />
-			<create_list name="$supplies" />
-			<create_list name="$needs" />
-			<create_list name="$innerList" />
-			<create_list name="$outerList" />
-			<create_list name="$tempList" />
+    <attention min="unknown">
+        <actions>
+            <label name="start" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ScriptStart'" output="false" append="false" />
+            <set_value name="$needFound" exact="false" />
+            <set_value name="$needFound2" exact="false" />
+            <set_value name="$supplyTarget" exact="0" />
+            <set_value name="$supplySource" exact="0" />
+            <create_list name="$supplies" />
+            <create_list name="$needs" />
+            <create_list name="$innerList" />
+            <create_list name="$outerList" />
+            <create_list name="$tempList" />
 
-			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
-			<set_value name="$cargo" exact="this.ship.cargo.list" />
+            <!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
+            <set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_if value="$cargo.count gt 0">
-				<run_script name="'mule.lib.empty_cargo'">
-					<param name="debugchance" value="$debugchance" />
-					<param name="debugFileName" value="$debugFileName" />
-					<param name="debugDirName" value="$debugDirName" />
-					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
-					<param name="cargo" value="$cargo" />
-				</run_script>
-			</do_if>
+            <do_if value="$cargo.count gt 0">
+                <run_script name="'mule.lib.empty_cargo'">
+                    <param name="debugchance" value="$debugchance" />
+                    <param name="debugFileName" value="$debugFileName" />
+                    <param name="debugDirName" value="$debugDirName" />
+                    <param name="logbookEntryTitle" value="$logbookEntryTitle" />
+                    <param name="cargo" value="$cargo" />
+                </run_script>
+            </do_if>
 
-			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />
-				<wait min="50ms" max="150ms" />
-				<resume label="start" />
-			</do_if>
+            <do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />
+                <wait min="50ms" max="150ms" />
+                <resume label="start" />
+            </do_if>
 
-			<!-- TODO: rewrite this block -->
-			<set_value name="$wareBasket" exact="$specialWareBasket" />
-			<do_if value="$wareBasket == []">
-				<do_if value="$sourceStation.tradewares.count">
-					<set_value name="$wareBasket" exact="$sourceStation.tradewares.list" />
-					<do_if value="$sourceStation.products.count">
-						<append_list_elements name="$wareBasket" other="$sourceStation.products.list" />
-					</do_if>
-				</do_if>
-				<do_elseif value="$sourceStation.products.count">
-					<set_value name="$wareBasket" exact="$sourceStation.products.list" />
-					<do_if value="$sourceStation.tradewares.count">
-						<append_list_elements name="$wareBasket" other="$sourceStation.tradewares.list" />
-					</do_if>
-				</do_elseif>
-			</do_if>
+            <!-- TODO: rewrite this block -->
+            <set_value name="$wareBasket" exact="$specialWareBasket" />
+            <do_if value="$wareBasket == []">
+                <do_if value="$sourceStation.tradewares.count">
+                    <set_value name="$wareBasket" exact="$sourceStation.tradewares.list" />
+                    <do_if value="$sourceStation.products.count">
+                        <append_list_elements name="$wareBasket" other="$sourceStation.products.list" />
+                    </do_if>
+                </do_if>
+                <do_elseif value="$sourceStation.products.count">
+                    <set_value name="$wareBasket" exact="$sourceStation.products.list" />
+                    <do_if value="$sourceStation.tradewares.count">
+                        <append_list_elements name="$wareBasket" other="$sourceStation.tradewares.list" />
+                    </do_if>
+                </do_elseif>
+            </do_if>
 
-			<set_value name="$distanceToSourceStation" exact="this.ship.gatedistance.{$sourceStation}"></set_value>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'gate distance from ship to source station: ' +$distanceToSourceStation" output="false" append="true" />
+            <set_value name="$distanceToSourceStation" exact="this.ship.gatedistance.{$sourceStation}"></set_value>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'gate distance from ship to source station: ' +$distanceToSourceStation" output="false" append="true" />
 
-			<find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" wares="$wareBasket" multiple="true">
-				<!-- this blacklist block shouldnt be needed unless the match_gate_distance has a max distance. If we ever do that we will need it so leaving it in -->
-				<match_seller>
-					<match_gate_distance object="this.ship" min="0">
-						<blacklist group="blacklistgroup.civilian" object="this.ship" />
-					</match_gate_distance>
-				</match_seller>
-			</find_sell_offer>
+            <find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" wares="$wareBasket" multiple="true">
+                <!-- this blacklist block shouldnt be needed unless the match_gate_distance has a max distance. If we ever do that we will need it so leaving it in -->
+                <match_seller>
+                    <match_gate_distance object="this.ship" min="0">
+                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                    </match_gate_distance>
+                </match_seller>
+            </find_sell_offer>
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'source station ' +$sourceStation.knownname" output="false" append="true" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'source station ' +$sourceStation.knownname" output="false" append="true" />
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'source station ' +$sourceStation.knownname" output="false" append="true" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'this is the wareBasket'" output="false" append="true" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$wareBasket" output="false" append="true" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'source station ' +$sourceStation.knownname" output="false" append="true" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'this is the wareBasket'" output="false" append="true" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$wareBasket" output="false" append="true" />
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are the sell offers'" output="false" append="true" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$supplies" output="false" append="true" />
-			<do_all exact="$supplies.count" counter="$i">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$supplies.{$i}.ware + ' ' +$supplies.{$i}.amount" output="false" append="true" />
-			</do_all>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are the sell offers'" output="false" append="true" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$supplies" output="false" append="true" />
+            <do_all exact="$supplies.count" counter="$i">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$supplies.{$i}.ware + ' ' +$supplies.{$i}.amount" output="false" append="true" />
+            </do_all>
 
-			<!-- Finding buyers -->
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are the customers'" output="false" append="true" />
-			<do_all exact="$destList.count" counter="$customer">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$destList.{$customer}.knownname" output="false" append="true" />
+            <!-- Finding buyers -->
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are the customers'" output="false" append="true" />
+            <do_all exact="$destList.count" counter="$customer">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$destList.{$customer}.knownname" output="false" append="true" />
 
-				<!-- customers here are intended to only be player owned warehouses, so there is no need to filter trades by blacklist -->
-				<find_buy_offer tradepartner="this.ship" buyer="$destList.{$customer}" result="$tempList" wares="$wareBasket" excludeempty="false" multiple="true">
-					<match_buyer>
-						<match_gate_distance object="$sourceStation" min="0">
-							<blacklist group="blacklistgroup.civilian" object="this.ship" />
-						</match_gate_distance>
-					</match_buyer>
-				</find_buy_offer>
+                <!-- customers here are intended to only be player owned warehouses, so there is no need to filter trades by blacklist -->
+                <find_buy_offer tradepartner="this.ship" buyer="$destList.{$customer}" result="$tempList" wares="$wareBasket" excludeempty="false" multiple="true">
+                    <match_buyer>
+                        <match_gate_distance object="$sourceStation" min="0">
+                            <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                        </match_gate_distance>
+                    </match_buyer>
+                </find_buy_offer>
 
-				<do_all exact="$tempList.count" counter="$tl">
-					<append_to_list name="$needs" exact="$tempList.{$tl}" />
-				</do_all>
-			</do_all>
+                <do_all exact="$tempList.count" counter="$tl">
+                    <append_to_list name="$needs" exact="$tempList.{$tl}" />
+                </do_all>
+            </do_all>
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are all customer buy orders'" output="false" append="true" />
-			<do_all exact="$needs.count" counter="$i">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$needs.{$i}.ware + ' ' +$needs.{$i}.amount" output="false" append="true" />
-			</do_all>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'these are all customer buy orders'" output="false" append="true" />
+            <do_all exact="$needs.count" counter="$i">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$needs.{$i}.ware + ' ' +$needs.{$i}.amount" output="false" append="true" />
+            </do_all>
 
-			<!-- Distribution Mule Routine -->
-			<do_all exact="2">
-				<do_if value="$needs.count gt 0 and $supplies.count gt 0">
-					<sort_trades name="$innerList" tradelist="$needs" sorter="totalvolume" />
-					<sort_trades name="$outerList" tradelist="$supplies" sorter="volume" />
+            <!-- Distribution Mule Routine -->
+            <do_all exact="2">
+                <do_if value="$needs.count gt 0 and $supplies.count gt 0">
+                    <sort_trades name="$innerList" tradelist="$needs" sorter="totalvolume" />
+                    <sort_trades name="$outerList" tradelist="$supplies" sorter="volume" />
 
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'static storage setting value. If no source ratios are above this, no trades will happen'" output="false" append="true" />
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$staticStorage" output="false" append="true" />
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'static storage setting value. If no source ratios are above this, no trades will happen'" output="false" append="true" />
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  ' +$staticStorage" output="false" append="true" />
 
-					<do_all exact="$outerList.count" counter="$idx">
-						<set_value name="$sourceCargoRatio" exact="($outerList.{$idx}.owner.cargo.{$outerList.{$idx}.ware}.count * 100.0 / [$outerList.{$idx}.owner.cargo.{$outerList.{$idx}.ware}.target, 1].max)" />
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  source cargo ratio for ' +$outerList.{$idx}.ware + ': ' +$sourceCargoRatio" output="false" append="true" />
+                    <do_all exact="$outerList.count" counter="$idx">
+                        <set_value name="$sourceCargoRatio" exact="($outerList.{$idx}.owner.cargo.{$outerList.{$idx}.ware}.count * 100.0 / [$outerList.{$idx}.owner.cargo.{$outerList.{$idx}.ware}.target, 1].max)" />
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  source cargo ratio for ' +$outerList.{$idx}.ware + ': ' +$sourceCargoRatio" output="false" append="true" />
 
-						<do_if value="(not $needFound) and ($sourceCargoRatio gt $staticStorage)">
-							<set_value name="$someOuter" exact="$outerList.{$idx}" />
+                        <do_if value="(not $needFound) and ($sourceCargoRatio gt $staticStorage)">
+                            <set_value name="$someOuter" exact="$outerList.{$idx}" />
 
-							<do_all exact="$innerList.count" counter="$ctr">
-								<set_value name="$targetCargoRatio" exact="($innerList.{$ctr}.owner.cargo.{$innerList.{$ctr}.ware}.count * 100.0 / [$innerList.{$ctr}.owner.cargo.{$innerList.{$ctr}.ware}.target, 1].max)" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  target cargo ratio for ' +$innerList.{$ctr}.ware + ': ' +$targetCargoRatio" output="false" append="true" />
-								<do_if value="(not $needFound) and ($targetCargoRatio lt $minStorage or ($sourceCargoRatio gt $maxStorage and $sourceCargoRatio gt ($targetCargoRatio + 10)))">
-									<set_value name="$someInner" exact="$innerList.{$ctr}" />
+                            <do_all exact="$innerList.count" counter="$ctr">
+                                <set_value name="$targetCargoRatio" exact="($innerList.{$ctr}.owner.cargo.{$innerList.{$ctr}.ware}.count * 100.0 / [$innerList.{$ctr}.owner.cargo.{$innerList.{$ctr}.ware}.target, 1].max)" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  target cargo ratio for ' +$innerList.{$ctr}.ware + ': ' +$targetCargoRatio" output="false" append="true" />
+                                <do_if value="(not $needFound) and ($targetCargoRatio lt $minStorage or ($sourceCargoRatio gt $maxStorage and $sourceCargoRatio gt ($targetCargoRatio + 10)))">
+                                    <set_value name="$someInner" exact="$innerList.{$ctr}" />
 
-									<do_if value="$someOuter.ware.id" exact="$someInner.ware.id">
-										<do_if value="$someInner.owner.owner == this.ship.owner">
-											<set_value name="$targetAmount" exact="$someInner.desiredamount" />
-										</do_if>
+                                    <do_if value="$someOuter.ware.id" exact="$someInner.ware.id">
+                                        <do_if value="$someInner.owner.owner == this.ship.owner">
+                                            <set_value name="$targetAmount" exact="$someInner.desiredamount" />
+                                        </do_if>
 
-										<do_else>
-											<set_value name="$targetAmount" exact="$someInner.amount" />
-										</do_else>
+                                        <do_else>
+                                            <set_value name="$targetAmount" exact="$someInner.amount" />
+                                        </do_else>
 
-										<set_value name="$cargoHauled" exact="[this.ship.cargo.{$someInner.ware}.free,$targetAmount,$someOuter.amount].min" />
-										<do_if value="($cargoHauled gt (this.ship.cargo.{$someInner.ware}.max / 1.25)) or ($needFound2 and ($cargoHauled gt (this.ship.cargo.{$someInner.ware}.max / 2.0))) ">
-											<set_value name="$supplyTarget" exact="$someInner" />
-											<set_value name="$supplySource" exact="$someOuter" />
-											<set_value name="$needFound" exact="true" />
-											<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'found a trade: ' +$someInner.ware + ' ' +$cargoHauled" output="false" append="true" />
-										</do_if>
-									</do_if>
-								</do_if>
-							</do_all>
+                                        <set_value name="$cargoHauled" exact="[this.ship.cargo.{$someInner.ware}.free,$targetAmount,$someOuter.amount].min" />
+                                        <do_if value="($cargoHauled gt (this.ship.cargo.{$someInner.ware}.max / 1.25)) or ($needFound2 and ($cargoHauled gt (this.ship.cargo.{$someInner.ware}.max / 2.0))) ">
+                                            <set_value name="$supplyTarget" exact="$someInner" />
+                                            <set_value name="$supplySource" exact="$someOuter" />
+                                            <set_value name="$needFound" exact="true" />
+                                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'found a trade: ' +$someInner.ware + ' ' +$cargoHauled" output="false" append="true" />
+                                        </do_if>
+                                    </do_if>
+                                </do_if>
+                            </do_all>
 
-							<!--need found -->
-							<do_if value="$needFound">
-								<create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$cargoHauled" immediate="false" />
-								<create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$cargoHauled" immediate="false" />
-							</do_if>
-						</do_if>
-					</do_all>
+                            <!--need found -->
+                            <do_if value="$needFound">
+                                <create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$cargoHauled" immediate="false" />
+                                <create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$cargoHauled" immediate="false" />
+                            </do_if>
+                        </do_if>
+                    </do_all>
 
-				</do_if> <!-- the stations have supply and demand -->
+                </do_if> <!-- the stations have supply and demand -->
 
-				<!-- I'm not at all confident that the objects in the match_gate_distance are all correct
-				since right now we don't have gate limits, it shouldn't matter, but if max distances are ever added
-				this will need to be definitively accurate 
-				What it looks like to me is that it's searching other stations owned by the destination to add their 
-				needs to the supply list -->
-				<set_value name="$needFound2" exact="$needFound" />
-				<set_value name="$needFound" exact="false" />
-				<find_buy_offer tradepartner="this.ship" buyer="$sourceStation" result="$needs" wares="$wareBasket" excludeempty="false" multiple="true">
-					<match_buyer>
-						<match_gate_distance object="this.ship" min="0">
-							<blacklist group="blacklistgroup.civilian" object="this.ship" />
-						</match_gate_distance>
-					</match_buyer>
-				</find_buy_offer>
+                <!-- I'm not at all confident that the objects in the match_gate_distance are all correct
+                since right now we don't have gate limits, it shouldn't matter, but if max distances are ever added
+                this will need to be definitively accurate 
+                What it looks like to me is that it's searching other stations owned by the destination to add their 
+                needs to the supply list -->
+                <set_value name="$needFound2" exact="$needFound" />
+                <set_value name="$needFound" exact="false" />
+                <find_buy_offer tradepartner="this.ship" buyer="$sourceStation" result="$needs" wares="$wareBasket" excludeempty="false" multiple="true">
+                    <match_buyer>
+                        <match_gate_distance object="this.ship" min="0">
+                            <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                        </match_gate_distance>
+                    </match_buyer>
+                </find_buy_offer>
 
-				<do_if value="$needFound2">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'supplyTarget for needFound2 block ' + typeof $supplyTarget.owner + ' ' +$supplyTarget.owner.knownname" output="false" append="true" />
+                <do_if value="$needFound2">
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'supplyTarget for needFound2 block ' + typeof $supplyTarget.owner + ' ' +$supplyTarget.owner.knownname" output="false" append="true" />
 
-					<set_value name="$seller" exact="$supplyTarget.owner" />
-					<find_sell_offer tradepartner="this.ship" seller="$seller" result="$supplies" wares="$wareBasket" multiple="true">
-						<match_seller>
-							<match_gate_distance object="$seller" min="0">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-						</match_seller>
-					</find_sell_offer>
-				</do_if>
-				<do_else>
-					<do_all exact="$destList.count" counter="$customer">
-						<find_sell_offer tradepartner="this.ship" seller="$destList.{$customer}" result="$tempList" wares="$wareBasket" multiple="true">
-							<match_seller>
-								<match_gate_distance object="$sourceStation" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-							</match_seller>
-						</find_sell_offer>
-						<do_all exact="$tempList.count" counter="$tl">
-							<append_to_list name="$supplies" exact="$tempList.{$tl}" />
-						</do_all>
-					</do_all>
-				</do_else>
-			</do_all>
+                    <set_value name="$seller" exact="$supplyTarget.owner" />
+                    <find_sell_offer tradepartner="this.ship" seller="$seller" result="$supplies" wares="$wareBasket" multiple="true">
+                        <match_seller>
+                            <match_gate_distance object="$seller" min="0">
+                                <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                            </match_gate_distance>
+                        </match_seller>
+                    </find_sell_offer>
+                </do_if>
+                <do_else>
+                    <do_all exact="$destList.count" counter="$customer">
+                        <find_sell_offer tradepartner="this.ship" seller="$destList.{$customer}" result="$tempList" wares="$wareBasket" multiple="true">
+                            <match_seller>
+                                <match_gate_distance object="$sourceStation" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                            </match_seller>
+                        </find_sell_offer>
+                        <do_all exact="$tempList.count" counter="$tl">
+                            <append_to_list name="$supplies" exact="$tempList.{$tl}" />
+                        </do_all>
+                    </do_all>
+                </do_else>
+            </do_all>
 
-			<remove_value name="$supplyTarget" />
-			<remove_value name="$supplySource" />
-			<remove_value name="$supplies" />
-			<remove_value name="$needs" />
-			<remove_value name="$innerList" />
-			<remove_value name="$outerList" />
-			<remove_value name="$sellspaces" />
-			<remove_value name="$tempList" />
+            <remove_value name="$supplyTarget" />
+            <remove_value name="$supplySource" />
+            <remove_value name="$supplies" />
+            <remove_value name="$needs" />
+            <remove_value name="$innerList" />
+            <remove_value name="$outerList" />
+            <remove_value name="$sellspaces" />
+            <remove_value name="$tempList" />
 
-			<wait min="3min" max="5min" />
-			<label name="end" />
-		</actions>
-	</attention>
+            <wait min="3min" max="5min" />
+            <label name="end" />
+        </actions>
+    </attention>
 </aiscript>

--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<aiscript name="distrimule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="2">
+<aiscript name="distrimule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="3">
 	<!-- Setup context menu order-->
 	<order id="DistriMule" name="{61552,3001}" description="{61552,3101}" category="trade" infinite="true">
 		<params>
@@ -41,6 +41,8 @@
 			<param name="destList" required="false" default="[]" type="list" text="{61552,3007}" comment="{61552,3107}">
 				<input_param name="type" value="'object'" />
 			</param>
+			<param name="restartScript" type="internal" default="false"/>
+
 		</params>
 		<requires>
 			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
@@ -65,12 +67,20 @@
 		<set_value name="$debugFileName" exact="'DistribMule - ' + this.ship.idcode"/>
 		<set_value name="$debugDirName" exact="'MulesExtended'"/>
 		<set_value name="$object" exact="this.assignedcontrolled" />
+		<set_value name="$logbookEntryTitle" exact="'DistribMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
 		<set_order_syncpoint_reached order="this.ship.order" />
 		<set_command_action commandaction="commandaction.searchingtrades" />
 		<do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
 			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
 		</do_if>
 	</init>
+
+	<patch sinceversion="3">
+		<!-- This will reissue any standing supply mule orders -->
+		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+		<debug_text text="'PATCH: Restarting distrib mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
+		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
+	</patch>
 
 	<attention min="unknown">
 		<actions>
@@ -86,64 +96,18 @@
 			<create_list name="$outerList" />
 			<create_list name="$tempList" />
 
-			<!-- Sell leftover cargo before resuming regular Mule routine -->
-			<set_value name="$profitScale" exact="50" />
-			<set_value name="$pilotSkill" exact="this.ship.pilot.skill.piloting" />
-			<set_value name="$maxBuyRelPrice" exact="((-0.325-0.025*($pilotSkill)f)/90.0-0.01)*($profitScale)f+1-(-0.325-0.025*($pilotSkill)f)/9.0" />
-			<set_value name="$searchStep" exact="(1.0-$maxBuyRelPrice)/4.0" />
-
+			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
 			<set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_all exact="$cargo.count" counter="$wareInCargo">
-				<wait min="50ms" max="150ms" />
-
-				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
-				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
-
-				<do_all exact="5" counter="$reduction">
-					<!--searching suiting buy offer, will search 5 times reducing requirements each time by 20% (just want to get rid of that stuff at some point)-->
-					<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$buyOffer" wares="$currentWare">
-						<match_buyer tradesknownto="this.owner">
-							<match_gate_distance object="this.ship" min="0" max="8">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-						<relativeprice min="-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001" />
-						<amount min="$amount*(0.8^($reduction-1))" />
-					</find_buy_offer>
-					<wait min="50ms" max="150ms" />
-
-					<do_if value="$buyOffer == null">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates :'+($maxSell+$reduction-1)" />
-						<continue />
-					</do_if>
-
-					<set_value name="$amount" exact="[$amount,$buyOffer.amount].min" />
-
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
-
-					<do_if value="$buyOffer.available">
-						<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" money="$buyOffer.unitprice*$amount" text="'Selling '+$amount+' '+$currentWare+', unitprice: '+$buyOffer.unitprice/100.0" />
-						<create_trade_order object="this.ship" amount="$amount" tradeoffer="$buyOffer" />
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  trade created'" />
-						<resume label="end" />
-					</do_if>
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  offer not available anymore'" />
-				</do_all>
-				<show_notification text="['DistribMule: '+this.ship.knownname+' ('+this.ship.idcode+')', '', 'can\'t empty cargo', [$amount+' '+$currentWare, 255, 192, 126]]" sound="notification_warning" />
-				<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'can\'t get rid of '+$amount+' '+$currentWare+' from cargo, what should I do?'" />
-			</do_all>
-			<remove_value name="$searchStep" />
-			<remove_value name="$cargo" />
-			<remove_value name="$buyOffer" />
+			<do_if value="$cargo.count gt 0">
+				<run_script name="'mule.lib.empty_cargo'">
+					<param name="debugchance" value="$debugchance" />
+					<param name="debugFileName" value="$debugFileName" />
+					<param name="debugDirName" value="$debugDirName" />
+					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
+					<param name="cargo" value="$cargo" />
+				</run_script>
+			</do_if>
 
 			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />

--- a/aiscripts/distrib_mule.xml
+++ b/aiscripts/distrib_mule.xml
@@ -76,7 +76,7 @@
     </init>
 
     <patch sinceversion="3">
-        <!-- This will reissue any standing supply mule orders -->
+        <!-- This will reissue any standing distrib mule orders -->
         <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
         <debug_text text="'PATCH: Restarting distrib mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
         <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>

--- a/aiscripts/mule.lib.empty_cargo.xml
+++ b/aiscripts/mule.lib.empty_cargo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<aiscript name="mule.lib.empty_cargo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="1">
+    <!-- triggers when a mule aiscript starts while the mule already has cargo in the hold -->
+    <!-- can happen because the player changes the ship's order, or when X4 invalidates a trade -->
+    <!-- we delete the ware, and give the player money at the ware's defined averageprice -->
+    <!-- this should avoid recurring "my mule is selling to the ai!!" bug reports -->
+    <!-- though I expect it to still result in new ones... -->
+    <params>
+		<param name="debugchance"/>
+		<param name="debugFileName"/>
+		<param name="debugDirName"/>
+        <param name="logbookEntryTitle" />
+        <param name="cargo" />
+    </params>
+    <attention min="unknown">
+        <actions>
+			<do_all exact="$cargo.count" counter="$wareInCargo">
+				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
+				<set_value name="$wareAveragePrice" exact="$currentWare.averageprice" />
+				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
+				<set_value name="$moneyToPlayer" exact="$amount * $wareAveragePrice" />
+				<reward_player money="$moneyToPlayer" />
+				<remove_cargo object="this.ship" ware="$currentWare" exact="$amount" />
+				<set_value name="$rewardLogText" exact="'rewarded player for ' +$amount + ' ' +$currentWare + ' at averageprice ' +$wareAveragePrice/100.0 + ' due to mule cargo emptying routine'" />
+				<write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$moneyToPlayer" text="$rewardLogText" />
+            </do_all>
+        </actions>
+    </attention>
+</aiscript>

--- a/aiscripts/mule.lib.empty_cargo.xml
+++ b/aiscripts/mule.lib.empty_cargo.xml
@@ -6,23 +6,23 @@
     <!-- this should avoid recurring "my mule is selling to the ai!!" bug reports -->
     <!-- though I expect it to still result in new ones... -->
     <params>
-		<param name="debugchance"/>
-		<param name="debugFileName"/>
-		<param name="debugDirName"/>
+        <param name="debugchance"/>
+        <param name="debugFileName"/>
+        <param name="debugDirName"/>
         <param name="logbookEntryTitle" />
         <param name="cargo" />
     </params>
     <attention min="unknown">
         <actions>
-			<do_all exact="$cargo.count" counter="$wareInCargo">
-				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
-				<set_value name="$wareAveragePrice" exact="$currentWare.averageprice" />
-				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<set_value name="$moneyToPlayer" exact="$amount * $wareAveragePrice" />
-				<reward_player money="$moneyToPlayer" />
-				<remove_cargo object="this.ship" ware="$currentWare" exact="$amount" />
-				<set_value name="$rewardLogText" exact="'rewarded player for ' +$amount + ' ' +$currentWare + ' at averageprice ' +$wareAveragePrice/100.0 + ' due to mule cargo emptying routine'" />
-				<write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$moneyToPlayer" text="$rewardLogText" />
+            <do_all exact="$cargo.count" counter="$wareInCargo">
+                <set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
+                <set_value name="$wareAveragePrice" exact="$currentWare.averageprice" />
+                <set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
+                <set_value name="$moneyToPlayer" exact="$amount * $wareAveragePrice" />
+                <reward_player money="$moneyToPlayer" />
+                <remove_cargo object="this.ship" ware="$currentWare" exact="$amount" />
+                <set_value name="$rewardLogText" exact="'rewarded player for ' +$amount + ' ' +$currentWare + ' at averageprice ' +$wareAveragePrice/100.0 + ' due to mule cargo emptying routine'" />
+                <write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$moneyToPlayer" text="$rewardLogText" />
             </do_all>
         </actions>
     </attention>

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<aiscript name="stationmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="6">
+<aiscript name="stationmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="7">
 	<!-- Setup context menu order -->
 	<order id="StationMule" name="{61552,2001}" description="{61552,2002}" category="trade" infinite="true">
 		<params>
@@ -63,9 +63,14 @@
 			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
 		</do_if>
 		<set_value name="$debugFileName" exact="'stationmule- ' + this.ship.idcode" />
+		<set_value name="$logbookEntryTitle" exact="'StationMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
+
 	</init>
 
-	<patch sinceversion="6">
+	<patch sinceversion="7">
+		<!-- This will reissue any standing supply mule orders -->
+		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+		<debug_text text="'PATCH: Restarting station mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
 		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
 	</patch>
 
@@ -93,65 +98,18 @@
 			<create_list name="$prio4" />
 			<create_list name="$prio5" />
 
-			<!-- Sell leftover cargo before resuming regular Mule routine -->
-			<set_value name="$profitScale" exact="50" />
-			<set_value name="$pilotSkill" exact="this.ship.pilot.skill.piloting" />
-			<set_value name="$maxBuyRelPrice" exact="((-0.325-0.025*($pilotSkill)f)/90.0-0.01)*($profitScale)f+1-(-0.325-0.025*($pilotSkill)f)/9.0" />
-			<set_value name="$searchStep" exact="(1.0-$maxBuyRelPrice)/4.0" />
-
+			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
 			<set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_all exact="$cargo.count" counter="$wareInCargo">
-				<wait min="50ms" max="150ms" />
-
-				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
-				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
-
-				<do_all exact="5" counter="$reduction">
-					<!--searching suiting buy offer, will search 5 times reducing requirements each time by 20% (just want to get rid of that stuff at some point)-->
-					<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$buyOffer" wares="$currentWare">
-						<match_buyer tradesknownto="this.owner">
-							<match_gate_distance object="this.ship" min="0" max="8">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-						<relativeprice min="-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001" />
-						<amount min="$amount*(0.8^($reduction-1))" />
-					</find_buy_offer>
-					<wait min="50ms" max="150ms" />
-
-					<do_if value="$buyOffer == null">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates :'+(8+$reduction-1)" />
-						<continue />
-					</do_if>
-
-					<set_value name="$amount" exact="[$amount,$buyOffer.amount].min" />
-
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
-
-					<do_if value="$buyOffer.available">
-						<write_to_logbook category="general" title="'stationmule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" money="$buyOffer.unitprice*$amount" text="'Selling '+$amount+' '+$currentWare+', unitprice: '+$buyOffer.unitprice/100.0" />
-						<create_trade_order object="this.ship" amount="$amount" tradeoffer="$buyOffer" />
-						<debug_to_file name="$debugFileName" directory="'MulesExtended'" text="'  trade created'" />
-						<resume label="end" />
-					</do_if>
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  offer not available anymore'" />
-				</do_all>
-				<show_notification text="['stationmule: '+this.ship.knownname+' ('+this.ship.idcode+')', '', 'can\'t empty cargo', [$amount+' '+$currentWare, 255, 192, 126]]" sound="notification_warning" />
-				<write_to_logbook category="general" title="'stationmule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'can\'t get rid of '+$amount+' '+$currentWare+' from cargo, what should I do?'" />
-				<resume label="endWait" />
-			</do_all>
-			<remove_value name="$searchStep" />
-			<remove_value name="$cargo" />
-			<remove_value name="$buyOffer" />
+			<do_if value="$cargo.count gt 0">
+				<run_script name="'mule.lib.empty_cargo'">
+					<param name="debugchance" value="$debugchance" />
+					<param name="debugFileName" value="$debugFileName" />
+					<param name="debugDirName" value="$debugDirName" />
+					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
+					<param name="cargo" value="$cargo" />
+				</run_script>
+			</do_if>
 
 			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'stationmule'" text="'  cargo is full =('" />

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -68,7 +68,7 @@
     </init>
 
     <patch sinceversion="7">
-        <!-- This will reissue any standing supply mule orders -->
+        <!-- This will reissue any standing station mule orders -->
         <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
         <debug_text text="'PATCH: Restarting station mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
         <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>

--- a/aiscripts/station_mule.xml
+++ b/aiscripts/station_mule.xml
@@ -1,541 +1,541 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <aiscript name="stationmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="7">
-	<!-- Setup context menu order -->
-	<order id="StationMule" name="{61552,2001}" description="{61552,2002}" category="trade" infinite="true">
-		<params>
-			<!-- menu option: Source Station (Define Source Station) -->
-			<param name="sourceStation" type="object" text="{61552,2002}" comment="{61552,2102}">
-				<input_param name="class" value="[class.station]" />
-			</param>
-			<!-- menu option: Target Station (Defines destination target) -->
-			<param name="targetStation" type="object" text="{61552,2003}" comment="{61552,2103}">
-				<input_param name="class" value="[class.station]" />
-			</param>
-			<!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
-			<param name="assignSrc" type="bool" default="false" text="{61552,2004}" comment="{61552,2104}" />
-			<!-- menu option: Include Energry Wares (Inlcudes energry cells if used) -->
-			<param name="incEgry" type="bool" default="false" text="{61552,2005}" comment="{61552,2105}" />
-			<!-- menu option: Include Food & Medical Wares (Inlcudes food and medical wares if used) -->
-			<param name="incFood" type="bool" default="false" text="{61552,2006}" comment="{61552,2106}" />
-			<!-- menu option: Supply First (Prioritize emptying sellers ware stocks if used) -->
-			<param name="supplyFirst" type="bool" default="false" text="{61552,2007}" comment="{61552,2107}" />
-			<!-- menu option: Drug Free (Never trade illegal wares if used) -->
-			<param name="drugFree" type="bool" default="false" text="{61552,2008}" comment="{61552,2108}" />
-			<!-- menu option: Drugs Only (Only trade illegal wares if used) -->
-			<param name="drugsOnly" type="bool" default="false" text="{61552,2009}" comment="{61552,2109}" />
-			<!-- menu option: Two-way Trade (Forces trading back and forth between the stations if used) -->
-			<param name="twoWay" type="bool" default="false" text="{61552,2010}" comment="{61552,2110}" />
-			<!-- menu option: Return Seller Priority (Forces seller priority on return if used) -->
-			<param name="twoWaySupplyFirst" type="bool" default="false" text="{61552,2011}" comment="{61552,2111}" />
-			<!-- menu option: No player in-system trade (Forbids all trades between all player owned objects in sector when ilde if used) -->
-			<param name="forbidTradeAll" type="bool" default="false" text="{61552,2012}" comment="{61552,2112}" />
-			<!-- menu option: Allow Low Volumes (Allow trades below 50% cargo capacity and below 80% cargo capacity for in-system trades if used) -->
-			<param name="allowLowVol" type="bool" default="false" text="{61552,2013}" comment="{61552,2113}" />
-			<!-- menu option: Make Target Warehouse (Mule turns target station into functional Trade Station like NPC, which can buy everything the source sells if used) -->
-			<param name="allowCreateTrade" type="bool" default="false" text="{61552,2014}" comment="{61552,2114}" />
-			<!-- Internal parameter used to restart the script on version update if required -->
-			<param name="restartScript" type="internal" default="false"/>
-		</params>
-		<requires>
-			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
-			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
-			<match shiptype="shiptype.lasertower" negate="true" />
-		</requires>
-	</order>
+    <!-- Setup context menu order -->
+    <order id="StationMule" name="{61552,2001}" description="{61552,2002}" category="trade" infinite="true">
+        <params>
+            <!-- menu option: Source Station (Define Source Station) -->
+            <param name="sourceStation" type="object" text="{61552,2002}" comment="{61552,2102}">
+                <input_param name="class" value="[class.station]" />
+            </param>
+            <!-- menu option: Target Station (Defines destination target) -->
+            <param name="targetStation" type="object" text="{61552,2003}" comment="{61552,2103}">
+                <input_param name="class" value="[class.station]" />
+            </param>
+            <!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
+            <param name="assignSrc" type="bool" default="false" text="{61552,2004}" comment="{61552,2104}" />
+            <!-- menu option: Include Energry Wares (Inlcudes energry cells if used) -->
+            <param name="incEgry" type="bool" default="false" text="{61552,2005}" comment="{61552,2105}" />
+            <!-- menu option: Include Food & Medical Wares (Inlcudes food and medical wares if used) -->
+            <param name="incFood" type="bool" default="false" text="{61552,2006}" comment="{61552,2106}" />
+            <!-- menu option: Supply First (Prioritize emptying sellers ware stocks if used) -->
+            <param name="supplyFirst" type="bool" default="false" text="{61552,2007}" comment="{61552,2107}" />
+            <!-- menu option: Drug Free (Never trade illegal wares if used) -->
+            <param name="drugFree" type="bool" default="false" text="{61552,2008}" comment="{61552,2108}" />
+            <!-- menu option: Drugs Only (Only trade illegal wares if used) -->
+            <param name="drugsOnly" type="bool" default="false" text="{61552,2009}" comment="{61552,2109}" />
+            <!-- menu option: Two-way Trade (Forces trading back and forth between the stations if used) -->
+            <param name="twoWay" type="bool" default="false" text="{61552,2010}" comment="{61552,2110}" />
+            <!-- menu option: Return Seller Priority (Forces seller priority on return if used) -->
+            <param name="twoWaySupplyFirst" type="bool" default="false" text="{61552,2011}" comment="{61552,2111}" />
+            <!-- menu option: No player in-system trade (Forbids all trades between all player owned objects in sector when ilde if used) -->
+            <param name="forbidTradeAll" type="bool" default="false" text="{61552,2012}" comment="{61552,2112}" />
+            <!-- menu option: Allow Low Volumes (Allow trades below 50% cargo capacity and below 80% cargo capacity for in-system trades if used) -->
+            <param name="allowLowVol" type="bool" default="false" text="{61552,2013}" comment="{61552,2113}" />
+            <!-- menu option: Make Target Warehouse (Mule turns target station into functional Trade Station like NPC, which can buy everything the source sells if used) -->
+            <param name="allowCreateTrade" type="bool" default="false" text="{61552,2014}" comment="{61552,2114}" />
+            <!-- Internal parameter used to restart the script on version update if required -->
+            <param name="restartScript" type="internal" default="false"/>
+        </params>
+        <requires>
+            <!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+            <!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+            <match shiptype="shiptype.lasertower" negate="true" />
+        </requires>
+    </order>
 
-	<interrupts>
-		<handler ref="AttackHandler" />
-		<handler ref="MissileLockHandler" />
-		<handler ref="ScannedHandler" />
-		<handler ref="InspectedHandler" />
-		<handler ref="FoundAbandonedHandler" />
-		<handler ref="ResupplyHandler" />
-		<handler ref="JobRemoveRequestHandler" />
-		<handler ref="TargetInvalidHandler" />
-	</interrupts>
+    <interrupts>
+        <handler ref="AttackHandler" />
+        <handler ref="MissileLockHandler" />
+        <handler ref="ScannedHandler" />
+        <handler ref="InspectedHandler" />
+        <handler ref="FoundAbandonedHandler" />
+        <handler ref="ResupplyHandler" />
+        <handler ref="JobRemoveRequestHandler" />
+        <handler ref="TargetInvalidHandler" />
+    </interrupts>
 
-	<init>
-		<set_value name="$debugchance" exact="100" />
-		<set_value name="$object" exact="this.assignedcontrolled" />
-		<set_order_syncpoint_reached order="this.ship.order" />
-		<set_command_action commandaction="commandaction.searchingtrades" />
-		<do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
-			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
-		</do_if>
-		<set_value name="$debugFileName" exact="'stationmule- ' + this.ship.idcode" />
-		<set_value name="$logbookEntryTitle" exact="'StationMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
+    <init>
+        <set_value name="$debugchance" exact="100" />
+        <set_value name="$object" exact="this.assignedcontrolled" />
+        <set_order_syncpoint_reached order="this.ship.order" />
+        <set_command_action commandaction="commandaction.searchingtrades" />
+        <do_if value="($sourceStation.owner == this.ship.owner) and ($assignSrc)">
+            <set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
+        </do_if>
+        <set_value name="$debugFileName" exact="'stationmule- ' + this.ship.idcode" />
+        <set_value name="$logbookEntryTitle" exact="'StationMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
 
-	</init>
+    </init>
 
-	<patch sinceversion="7">
-		<!-- This will reissue any standing supply mule orders -->
-		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
-		<debug_text text="'PATCH: Restarting station mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
-		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
-	</patch>
+    <patch sinceversion="7">
+        <!-- This will reissue any standing supply mule orders -->
+        <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+        <debug_text text="'PATCH: Restarting station mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
+        <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
+    </patch>
 
-	<attention min="unknown">
-		<actions>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'starting log file'" append="false" output="false" />
+    <attention min="unknown">
+        <actions>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'starting log file'" append="false" output="false" />
 
-			<label name="start" />
-			<set_value name="$loops" exact="2" />
-			<do_if value="not $forbidTradeAll">
-				<set_value name="$loops" exact="4" />
-			</do_if>
+            <label name="start" />
+            <set_value name="$loops" exact="2" />
+            <do_if value="not $forbidTradeAll">
+                <set_value name="$loops" exact="4" />
+            </do_if>
 
-			<set_value name="$supplyFirstLocal" exact="$supplyFirst" />
-			<set_value name="$needFound" exact="false" />
-			<set_value name="$needFound2" exact="false" />
-			<set_value name="$supplyTarget" exact="0" />
-			<set_value name="$supplySource" exact="0" />
-			<create_list name="$supplies" />
-			<create_list name="$needs" />
-			<create_list name="$innerList" />
-			<create_list name="$outerList" />
-			<create_list name="$prio2" />
-			<create_list name="$prio3" />
-			<create_list name="$prio4" />
-			<create_list name="$prio5" />
+            <set_value name="$supplyFirstLocal" exact="$supplyFirst" />
+            <set_value name="$needFound" exact="false" />
+            <set_value name="$needFound2" exact="false" />
+            <set_value name="$supplyTarget" exact="0" />
+            <set_value name="$supplySource" exact="0" />
+            <create_list name="$supplies" />
+            <create_list name="$needs" />
+            <create_list name="$innerList" />
+            <create_list name="$outerList" />
+            <create_list name="$prio2" />
+            <create_list name="$prio3" />
+            <create_list name="$prio4" />
+            <create_list name="$prio5" />
 
-			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
-			<set_value name="$cargo" exact="this.ship.cargo.list" />
+            <!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
+            <set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_if value="$cargo.count gt 0">
-				<run_script name="'mule.lib.empty_cargo'">
-					<param name="debugchance" value="$debugchance" />
-					<param name="debugFileName" value="$debugFileName" />
-					<param name="debugDirName" value="$debugDirName" />
-					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
-					<param name="cargo" value="$cargo" />
-				</run_script>
-			</do_if>
+            <do_if value="$cargo.count gt 0">
+                <run_script name="'mule.lib.empty_cargo'">
+                    <param name="debugchance" value="$debugchance" />
+                    <param name="debugFileName" value="$debugFileName" />
+                    <param name="debugDirName" value="$debugDirName" />
+                    <param name="logbookEntryTitle" value="$logbookEntryTitle" />
+                    <param name="cargo" value="$cargo" />
+                </run_script>
+            </do_if>
 
-			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'stationmule'" text="'  cargo is full =('" />
-				<wait min="50ms" max="150ms" />
-				<resume label="endWait" />
-			</do_if>
+            <do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'stationmule'" text="'  cargo is full =('" />
+                <wait min="50ms" max="150ms" />
+                <resume label="endWait" />
+            </do_if>
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'sourceStation: ' +$sourceStation.knownname" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'targetStation: ' +$targetStation.knownname" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'sourceStation: ' +$sourceStation.knownname" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'targetStation: ' +$targetStation.knownname" />
 
-			<!-- Add trade ware orders to target station if make target warehouse is checked -->
-			<!-- a trade station seems to have both tradewares and products, so I modified this -->
-			<!-- TODO review/rewrite this -->
-			<do_if value="$allowCreateTrade and ($targetStation.owner == this.ship.owner)">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----entering make target warehouse block'" />
-				<set_value name="$sourceTradeWares" exact="0" />
-				<set_value name="$sourceProductWares" exact="0" />
-				<set_value name="$targetTradeWares" exact="0" />
-				<set_value name="$targetProductWares" exact="0" />
-				<do_if value="$sourceStation.products.count gt 0">
-					<set_value name="$sourceProductWares" exact="$sourceStation.products.count" />
-				</do_if>
-				<do_if value="$sourceStation.tradewares.count gt 0">
-					<set_value name="$sourceTradeWares" exact="$sourceStation.tradewares.count" />
-				</do_if>
-				<do_if value="$targetStation.tradewares.count gt 0">
-					<set_value name="$targetTradeWares" exact="$targetStation.tradewares.count" />
-				</do_if>
-				<do_if value="$targetStation.products.count gt 0">
-					<set_value name="$targetProductWares" exact="$targetStation.products.count" />
-				</do_if>
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceProductWares: ' +$sourceProductWares" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetProductWares: ' +$targetProductWares" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceTradetWares: ' +$sourceTradeWares" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetTradeWares: ' +$targetTradeWares" />
+            <!-- Add trade ware orders to target station if make target warehouse is checked -->
+            <!-- a trade station seems to have both tradewares and products, so I modified this -->
+            <!-- TODO review/rewrite this -->
+            <do_if value="$allowCreateTrade and ($targetStation.owner == this.ship.owner)">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----entering make target warehouse block'" />
+                <set_value name="$sourceTradeWares" exact="0" />
+                <set_value name="$sourceProductWares" exact="0" />
+                <set_value name="$targetTradeWares" exact="0" />
+                <set_value name="$targetProductWares" exact="0" />
+                <do_if value="$sourceStation.products.count gt 0">
+                    <set_value name="$sourceProductWares" exact="$sourceStation.products.count" />
+                </do_if>
+                <do_if value="$sourceStation.tradewares.count gt 0">
+                    <set_value name="$sourceTradeWares" exact="$sourceStation.tradewares.count" />
+                </do_if>
+                <do_if value="$targetStation.tradewares.count gt 0">
+                    <set_value name="$targetTradeWares" exact="$targetStation.tradewares.count" />
+                </do_if>
+                <do_if value="$targetStation.products.count gt 0">
+                    <set_value name="$targetProductWares" exact="$targetStation.products.count" />
+                </do_if>
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceProductWares: ' +$sourceProductWares" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetProductWares: ' +$targetProductWares" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceTradetWares: ' +$sourceTradeWares" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetTradeWares: ' +$targetTradeWares" />
 
-				<set_value name="$didWeCallAddTradeware" exact="false" />
-				<!-- trade wares -->
-				<do_all exact="$sourceTradeWares" counter="$cts">
-					<set_value name="$wareFound" exact="false" />
-					<do_if value="$sourceStation.tradewares.count gt 0">
-						<do_if value="$targetTradeWares gt 0">
-							<do_if value="$targetStation.tradewares.{$sourceStation.tradewares.{$cts}}.exists">
-								<set_value name="$wareFound" exact="true" />
-							</do_if>
-						</do_if>
-					</do_if>
-					<do_if value="not $wareFound">
-						<do_if value="$sourceStation.tradewares.count gt 0">
-							<add_tradeware object="$targetStation" ware="$sourceStation.tradewares.{$cts}" allowbuy="true" allowsell="true" lockavgprice="false" />
-							<set_value name="$didWeCallAddTradeware" exact="true" />
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  added tradewware 1: ' +$sourceStation.tradewares.{$cts}" />
-						</do_if>
-					</do_if>
-				</do_all>
-				<!-- product wares -->
-				<do_all exact="$sourceProductWares" counter="$cts">
-					<set_value name="$wareFound" exact="false" />
-					<do_if value="$sourceStation.products.count gt 0">
-						<do_if value="$targetProductWares gt 0">
-							<do_if value="$targetStation.products.{$sourceStation.products.{$cts}}.exists">
-								<set_value name="$wareFound" exact="true" />
-							</do_if>
-						</do_if>
-						<do_elseif value="$targetTradeWares gt 0">
-							<do_if value="$targetStation.tradewares.{$sourceStation.products.{$cts}}.exists">
-								<set_value name="$wareFound" exact="true" />
-							</do_if>
-						</do_elseif>
-					</do_if>
+                <set_value name="$didWeCallAddTradeware" exact="false" />
+                <!-- trade wares -->
+                <do_all exact="$sourceTradeWares" counter="$cts">
+                    <set_value name="$wareFound" exact="false" />
+                    <do_if value="$sourceStation.tradewares.count gt 0">
+                        <do_if value="$targetTradeWares gt 0">
+                            <do_if value="$targetStation.tradewares.{$sourceStation.tradewares.{$cts}}.exists">
+                                <set_value name="$wareFound" exact="true" />
+                            </do_if>
+                        </do_if>
+                    </do_if>
+                    <do_if value="not $wareFound">
+                        <do_if value="$sourceStation.tradewares.count gt 0">
+                            <add_tradeware object="$targetStation" ware="$sourceStation.tradewares.{$cts}" allowbuy="true" allowsell="true" lockavgprice="false" />
+                            <set_value name="$didWeCallAddTradeware" exact="true" />
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  added tradewware 1: ' +$sourceStation.tradewares.{$cts}" />
+                        </do_if>
+                    </do_if>
+                </do_all>
+                <!-- product wares -->
+                <do_all exact="$sourceProductWares" counter="$cts">
+                    <set_value name="$wareFound" exact="false" />
+                    <do_if value="$sourceStation.products.count gt 0">
+                        <do_if value="$targetProductWares gt 0">
+                            <do_if value="$targetStation.products.{$sourceStation.products.{$cts}}.exists">
+                                <set_value name="$wareFound" exact="true" />
+                            </do_if>
+                        </do_if>
+                        <do_elseif value="$targetTradeWares gt 0">
+                            <do_if value="$targetStation.tradewares.{$sourceStation.products.{$cts}}.exists">
+                                <set_value name="$wareFound" exact="true" />
+                            </do_if>
+                        </do_elseif>
+                    </do_if>
 
-					<do_if value="not $wareFound">
-						<do_if value="$sourceStation.products.count gt 0">
-							<add_tradeware object="$targetStation" ware="$sourceStation.products.{$cts}" allowbuy="true" allowsell="true" lockavgprice="false" />
-							<set_value name="$didWeCallAddTradeware" exact="true" />
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  added tradeware 2: ' +$sourceStation.products.{$cts}" />
-						</do_if>
-					</do_if>
-				</do_all>
-				<remove_value name="$sourceTradeWares" />
-				<remove_value name="$sourceProductWares" />
-				<remove_value name="$targetTradeWares" />
-				<remove_value name="$targetProductWares" />
-				<do_if value="$didWeCallAddTradeware">
-					<!-- show notification on warehouse created and call create log-book entry. -->
-					<create_list name="$notif" />
-					<!-- message needs to be short or it won't fit -->
-					<append_to_list name="$notif" exact="'StM ' +this.ship.idcode" />
-					<append_to_list name="$notif" exact="'I added tradewares to a warehouse' " />
-					<show_notification text="$notif" sound="null" />
-					<write_to_logbook category="general" title="'stationmule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'Has added tradewares to '+$targetStation.name+' '" />
-					<remove_value name="$notif" />
-				</do_if>
-			</do_if>
+                    <do_if value="not $wareFound">
+                        <do_if value="$sourceStation.products.count gt 0">
+                            <add_tradeware object="$targetStation" ware="$sourceStation.products.{$cts}" allowbuy="true" allowsell="true" lockavgprice="false" />
+                            <set_value name="$didWeCallAddTradeware" exact="true" />
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  added tradeware 2: ' +$sourceStation.products.{$cts}" />
+                        </do_if>
+                    </do_if>
+                </do_all>
+                <remove_value name="$sourceTradeWares" />
+                <remove_value name="$sourceProductWares" />
+                <remove_value name="$targetTradeWares" />
+                <remove_value name="$targetProductWares" />
+                <do_if value="$didWeCallAddTradeware">
+                    <!-- show notification on warehouse created and call create log-book entry. -->
+                    <create_list name="$notif" />
+                    <!-- message needs to be short or it won't fit -->
+                    <append_to_list name="$notif" exact="'StM ' +this.ship.idcode" />
+                    <append_to_list name="$notif" exact="'I added tradewares to a warehouse' " />
+                    <show_notification text="$notif" sound="null" />
+                    <write_to_logbook category="general" title="'stationmule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'Has added tradewares to '+$targetStation.name+' '" />
+                    <remove_value name="$notif" />
+                </do_if>
+            </do_if>
 
-			<!-- these don't need blacklist filtering because the player picked the stations themselves in the UI -->
-			<find_buy_offer tradepartner="this.ship" buyer="$targetStation" result="$needs" excludeempty="false" multiple="true">
-				<match_buyer>
-					<match_gate_distance object="$sourceStation" min="0">
-						<blacklist group="blacklistgroup.civilian" object="this.ship" />
-					</match_gate_distance>
-				</match_buyer>
-			</find_buy_offer>
-			<find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" multiple="true">
-				<match_seller>
-					<match_gate_distance object="this.ship" min="0">
-						<blacklist group="blacklistgroup.civilian" object="this.ship" />
-					</match_gate_distance>
-				</match_seller>
-			</find_sell_offer>
+            <!-- these don't need blacklist filtering because the player picked the stations themselves in the UI -->
+            <find_buy_offer tradepartner="this.ship" buyer="$targetStation" result="$needs" excludeempty="false" multiple="true">
+                <match_buyer>
+                    <match_gate_distance object="$sourceStation" min="0">
+                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                    </match_gate_distance>
+                </match_buyer>
+            </find_buy_offer>
+            <find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" multiple="true">
+                <match_seller>
+                    <match_gate_distance object="this.ship" min="0">
+                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                    </match_gate_distance>
+                </match_seller>
+            </find_sell_offer>
 
-			<!-- Station Mule Routines -->
-			<!-- if interrupted during loop, will restart here -->
-			<label name="mainRoutine" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'----- main station mule routine'" />
-			<do_all exact="$loops" counter="$loop">
-				<do_if value="$needs.count gt 0 and $supplies.count gt 0">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  found ' +$needs.count +' needs and ' +$supplies.count + ' supplies'" />
-					<set_value name="$outerList" exact="[]" />
-					<!-- Sort Trades -->
-					<do_if value="$supplyFirstLocal">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority setting needs to innerList and supplies to outerList sorted by stocklevel descending'" />
-						<set_value name="$innerList" exact="$needs" />
+            <!-- Station Mule Routines -->
+            <!-- if interrupted during loop, will restart here -->
+            <label name="mainRoutine" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'----- main station mule routine'" />
+            <do_all exact="$loops" counter="$loop">
+                <do_if value="$needs.count gt 0 and $supplies.count gt 0">
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  found ' +$needs.count +' needs and ' +$supplies.count + ' supplies'" />
+                    <set_value name="$outerList" exact="[]" />
+                    <!-- Sort Trades -->
+                    <do_if value="$supplyFirstLocal">
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority setting needs to innerList and supplies to outerList sorted by stocklevel descending'" />
+                        <set_value name="$innerList" exact="$needs" />
 
-						<!-- shuffling due to advice in sort_trades docstring, and reversing list to sort descending -->
-						<shuffle_list list="$supplies" />
-						<sort_trades name="$dummyList" tradelist="$supplies" sorter="stocklevel" />
+                        <!-- shuffling due to advice in sort_trades docstring, and reversing list to sort descending -->
+                        <shuffle_list list="$supplies" />
+                        <sort_trades name="$dummyList" tradelist="$supplies" sorter="stocklevel" />
 
-						<set_value name="$outerList" exact="[]"/>
-						<do_all exact="$dummyList.count" counter="$dummy" reverse="true">
-							<append_to_list name="$outerList" exact="$dummyList.{$dummy}" />
-						</do_all>
-						<remove_value name="$dummyList" />
-						<do_all exact="$outerList.count" counter="$i">
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' + $outerList.{$i}.ware + ' ' + $outerList.{$i}.volume + ' ' + $outerList.{$i}.stocklevel" />
-						</do_all>
-					</do_if>
-					<do_else>
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority not set, evaluating our own priorities '" />
-						<set_value name="$prio2" exact="[]" />
-						<set_value name="$prio3" exact="[]" />
-						<set_value name="$prio4" exact="[]" />
-						<set_value name="$prio5" exact="[]" />
-						<set_value name="$innerList" exact="$supplies" />
-						<shuffle_list list="$needs" />
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  needs'" />
-						<do_all exact="$needs.count" counter="$nSort">
-							<set_value name="$someTrade" exact="$needs.{$nSort}" />
-							<set_value name="$isMadeAndUsed" exact="$someTrade.owner.products.{$someTrade.ware}.exists" />
-							<set_value name="$isTradeWare" exact="$someTrade.owner.tradewares.{$someTrade.ware}.exists" />
-							<set_value name="$cargoRatio" exact="($someTrade.owner.cargo.{$someTrade.ware}.count * 100.0 / [$someTrade.owner.cargo.{$someTrade.ware}.target, 1].max)" />
-							<do_if value="(not $isMadeAndUsed) and (not $isTradeWare) and $cargoRatio lt 10">
-								<append_to_list name="$outerList" exact="$someTrade" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isMadeAndUsed and not isTradeWare and cargoRatio lt 10. appended to outerList'" />
-							</do_if>
-							<do_elseif value="(not $isMadeAndUsed) and (not $isTradeWare) and $cargoRatio lt 25">
-								<append_to_list name="$prio2" exact="$someTrade" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isMadeAndUsed and not isTradeWare and cargoRatio lt 25. appended to prio2'" />
-							</do_elseif>
-							<do_elseif value="(not $isTradeWare) and $cargoRatio lt 50">
-								<append_to_list name="$prio3" exact="$someTrade" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isTradeWare and cargoRatio lt 50. appended to prio3'" />
-							</do_elseif>
-							<do_elseif value="(not $isTradeWare) and $cargoRatio lt 75">
-								<append_to_list name="$prio4" exact="$someTrade" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + '  not isTradeWare and cargoRatio lt 75. appended to prio4'" />
-							</do_elseif>
-							<do_else>
-								<append_to_list name="$prio5" exact="$someTrade" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' no other criteria met. appended to prio5'" />
-							</do_else>
-						</do_all>
-						<do_all exact="$prio2.count" counter="$p2">
-							<append_to_list name="$outerList" exact="$prio2.{$p2}" />
-						</do_all>
-						<do_all exact="$prio3.count" counter="$p3">
-							<append_to_list name="$outerList" exact="$prio3.{$p3}" />
-						</do_all>
-						<do_all exact="$prio4.count" counter="$p4">
-							<append_to_list name="$outerList" exact="$prio4.{$p4}" />
-						</do_all>
-						<do_all exact="$prio5.count" counter="$p5">
-							<append_to_list name="$outerList" exact="$prio5.{$p5}" />
-						</do_all>
-					</do_else>
+                        <set_value name="$outerList" exact="[]"/>
+                        <do_all exact="$dummyList.count" counter="$dummy" reverse="true">
+                            <append_to_list name="$outerList" exact="$dummyList.{$dummy}" />
+                        </do_all>
+                        <remove_value name="$dummyList" />
+                        <do_all exact="$outerList.count" counter="$i">
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' + $outerList.{$i}.ware + ' ' + $outerList.{$i}.volume + ' ' + $outerList.{$i}.stocklevel" />
+                        </do_all>
+                    </do_if>
+                    <do_else>
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceStation priority not set, evaluating our own priorities '" />
+                        <set_value name="$prio2" exact="[]" />
+                        <set_value name="$prio3" exact="[]" />
+                        <set_value name="$prio4" exact="[]" />
+                        <set_value name="$prio5" exact="[]" />
+                        <set_value name="$innerList" exact="$supplies" />
+                        <shuffle_list list="$needs" />
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  needs'" />
+                        <do_all exact="$needs.count" counter="$nSort">
+                            <set_value name="$someTrade" exact="$needs.{$nSort}" />
+                            <set_value name="$isMadeAndUsed" exact="$someTrade.owner.products.{$someTrade.ware}.exists" />
+                            <set_value name="$isTradeWare" exact="$someTrade.owner.tradewares.{$someTrade.ware}.exists" />
+                            <set_value name="$cargoRatio" exact="($someTrade.owner.cargo.{$someTrade.ware}.count * 100.0 / [$someTrade.owner.cargo.{$someTrade.ware}.target, 1].max)" />
+                            <do_if value="(not $isMadeAndUsed) and (not $isTradeWare) and $cargoRatio lt 10">
+                                <append_to_list name="$outerList" exact="$someTrade" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isMadeAndUsed and not isTradeWare and cargoRatio lt 10. appended to outerList'" />
+                            </do_if>
+                            <do_elseif value="(not $isMadeAndUsed) and (not $isTradeWare) and $cargoRatio lt 25">
+                                <append_to_list name="$prio2" exact="$someTrade" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isMadeAndUsed and not isTradeWare and cargoRatio lt 25. appended to prio2'" />
+                            </do_elseif>
+                            <do_elseif value="(not $isTradeWare) and $cargoRatio lt 50">
+                                <append_to_list name="$prio3" exact="$someTrade" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' not isTradeWare and cargoRatio lt 50. appended to prio3'" />
+                            </do_elseif>
+                            <do_elseif value="(not $isTradeWare) and $cargoRatio lt 75">
+                                <append_to_list name="$prio4" exact="$someTrade" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + '  not isTradeWare and cargoRatio lt 75. appended to prio4'" />
+                            </do_elseif>
+                            <do_else>
+                                <append_to_list name="$prio5" exact="$someTrade" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'    ' +$someTrade.ware + ' no other criteria met. appended to prio5'" />
+                            </do_else>
+                        </do_all>
+                        <do_all exact="$prio2.count" counter="$p2">
+                            <append_to_list name="$outerList" exact="$prio2.{$p2}" />
+                        </do_all>
+                        <do_all exact="$prio3.count" counter="$p3">
+                            <append_to_list name="$outerList" exact="$prio3.{$p3}" />
+                        </do_all>
+                        <do_all exact="$prio4.count" counter="$p4">
+                            <append_to_list name="$outerList" exact="$prio4.{$p4}" />
+                        </do_all>
+                        <do_all exact="$prio5.count" counter="$p5">
+                            <append_to_list name="$outerList" exact="$prio5.{$p5}" />
+                        </do_all>
+                    </do_else>
 
-					<!-- exclude energy cells -->
-					<do_all exact="$outerList.count" counter="$idx">
-						<do_if value="not $needFound">
-							<set_value name="$someOuter" exact="$outerList.{$idx}" />
-							<set_value name="$wareName" exact="$someOuter.ware.name" />
-							<!-- target is 0 when ware used only to build drones -->
-							<do_if value="($someOuter.ware.id == 'energycells') and (not $incEgry) and  ($someOuter.owner.class != class.buildstorage)">
-								<set_value name="$wareName" exact="'NOPE'" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed an energy cells trade'" />
-							</do_if>
+                    <!-- exclude energy cells -->
+                    <do_all exact="$outerList.count" counter="$idx">
+                        <do_if value="not $needFound">
+                            <set_value name="$someOuter" exact="$outerList.{$idx}" />
+                            <set_value name="$wareName" exact="$someOuter.ware.name" />
+                            <!-- target is 0 when ware used only to build drones -->
+                            <do_if value="($someOuter.ware.id == 'energycells') and (not $incEgry) and  ($someOuter.owner.class != class.buildstorage)">
+                                <set_value name="$wareName" exact="'NOPE'" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed an energy cells trade'" />
+                            </do_if>
 
-							<!-- exclude food & meds -->
-							<do_if value="not $incFood">
-								<do_if value="$someOuter.ware.id" exact="'foodrations'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a food rations trade.'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'nostropoil'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a nostrop oil trade.'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'sojahusk'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a soja husk trade.'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'terranmre'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a terran mre trade.'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'medicalsupplies'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a medical supplies trade'" />
-								</do_if>
-							</do_if>
+                            <!-- exclude food & meds -->
+                            <do_if value="not $incFood">
+                                <do_if value="$someOuter.ware.id" exact="'foodrations'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a food rations trade.'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'nostropoil'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a nostrop oil trade.'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'sojahusk'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a soja husk trade.'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'terranmre'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a terran mre trade.'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'medicalsupplies'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a medical supplies trade'" />
+                                </do_if>
+                            </do_if>
 
-							<!-- exclude illegal wares (Whoop whopp this is the police.) -->
-							<do_if value="$drugFree">
-								<do_if value="$someOuter.ware.id" exact="'spacefuel'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a spacefuel trade'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'spaceweed'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a spaceweed trade'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'majadust'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a majadust trade'" />
-								</do_if>
-								<do_if value="$someOuter.ware.id" exact="'stimulants'">
-									<set_value name="$wareName" exact="'NOPE'" />
-									<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a stimulants trade'" />
-								</do_if>
-							</do_if>
+                            <!-- exclude illegal wares (Whoop whopp this is the police.) -->
+                            <do_if value="$drugFree">
+                                <do_if value="$someOuter.ware.id" exact="'spacefuel'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a spacefuel trade'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'spaceweed'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a spaceweed trade'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'majadust'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a majadust trade'" />
+                                </do_if>
+                                <do_if value="$someOuter.ware.id" exact="'stimulants'">
+                                    <set_value name="$wareName" exact="'NOPE'" />
+                                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed a stimulants trade'" />
+                                </do_if>
+                            </do_if>
 
-							<!-- Only allow illegal wares (Infected Mushroom...) -->
-							<do_if value="$drugsOnly">
-								<do_if value="$someOuter.ware.id" exact="not 'spacefuel'">
-									<do_if value="$someOuter.ware.id" exact="not 'spaceweed'">
-										<do_if value="$someOuter.ware.id" exact="not 'majadust'">
-											<do_if value="$someOuter.ware.id" exact="not 'stimulants'">
-												<set_value name="$wareName" exact="'NOPE'" />
-												<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed ' +$someOuter.ware +' because its not illegal'" />
-											</do_if>
-										</do_if>
-									</do_if>
-								</do_if>
-							</do_if>
+                            <!-- Only allow illegal wares (Infected Mushroom...) -->
+                            <do_if value="$drugsOnly">
+                                <do_if value="$someOuter.ware.id" exact="not 'spacefuel'">
+                                    <do_if value="$someOuter.ware.id" exact="not 'spaceweed'">
+                                        <do_if value="$someOuter.ware.id" exact="not 'majadust'">
+                                            <do_if value="$someOuter.ware.id" exact="not 'stimulants'">
+                                                <set_value name="$wareName" exact="'NOPE'" />
+                                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  removed ' +$someOuter.ware +' because its not illegal'" />
+                                            </do_if>
+                                        </do_if>
+                                    </do_if>
+                                </do_if>
+                            </do_if>
 
-							<do_all exact="$innerList.count" counter="$ctr">
-								<!-- need found -->
-								<do_if value="not $needFound">
-									<set_value name="$someInner" exact="$innerList.{$ctr}" />
-									<do_if value="$wareName" exact="$someInner.ware.name">
-										<do_if value="$supplyFirstLocal">
-											<set_value name="$supplyTarget" exact="$someInner" />
-											<set_value name="$supplySource" exact="$someOuter" />
-										</do_if>
-										<do_else>
-											<set_value name="$supplyTarget" exact="$someOuter" />
-											<set_value name="$supplySource" exact="$someInner" />
-										</do_else>
+                            <do_all exact="$innerList.count" counter="$ctr">
+                                <!-- need found -->
+                                <do_if value="not $needFound">
+                                    <set_value name="$someInner" exact="$innerList.{$ctr}" />
+                                    <do_if value="$wareName" exact="$someInner.ware.name">
+                                        <do_if value="$supplyFirstLocal">
+                                            <set_value name="$supplyTarget" exact="$someInner" />
+                                            <set_value name="$supplySource" exact="$someOuter" />
+                                        </do_if>
+                                        <do_else>
+                                            <set_value name="$supplyTarget" exact="$someOuter" />
+                                            <set_value name="$supplySource" exact="$someInner" />
+                                        </do_else>
 
-										<set_value name="$targetIsResource" exact="$supplyTarget.owner.resources.{$supplyTarget.ware}.exists or $supplyTarget.owner.supplyresources.{$supplyTarget.ware}.exists"/>
-										<set_value name="$targetIsProduct" exact="$supplyTarget.owner.products.{$supplyTarget.ware}.exists"/>
-										<!-- X4 treats products and resources always as tradewares... -->
-										<set_value name="$targetIsWare" exact="$supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists"/>
+                                        <set_value name="$targetIsResource" exact="$supplyTarget.owner.resources.{$supplyTarget.ware}.exists or $supplyTarget.owner.supplyresources.{$supplyTarget.ware}.exists"/>
+                                        <set_value name="$targetIsProduct" exact="$supplyTarget.owner.products.{$supplyTarget.ware}.exists"/>
+                                        <!-- X4 treats products and resources always as tradewares... -->
+                                        <set_value name="$targetIsWare" exact="$supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists"/>
 
-										<set_value name="$sourceIsResource" exact="$supplySource.owner.resources.{$supplySource.ware}.exists or $supplySource.owner.supplyresources.{$supplySource.ware}.exists"/>
-										<set_value name="$sourceIsProduct" exact="$supplySource.owner.products.{$supplySource.ware}.exists"/>
-										<!-- X4 treats products and resources always as tradewares... -->
-										<set_value name="$sourceIsWare" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists"/>
+                                        <set_value name="$sourceIsResource" exact="$supplySource.owner.resources.{$supplySource.ware}.exists or $supplySource.owner.supplyresources.{$supplySource.ware}.exists"/>
+                                        <set_value name="$sourceIsProduct" exact="$supplySource.owner.products.{$supplySource.ware}.exists"/>
+                                        <!-- X4 treats products and resources always as tradewares... -->
+                                        <set_value name="$sourceIsWare" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists"/>
 
-										<set_value name="$targetIsResourceOnly" exact="$targetIsResource and (not $targetIsProduct)"/>
-										<set_value name="$targetIsProductOnly" exact="(not $targetIsResource) and $targetIsProduct"/>
-										<set_value name="$targetIsIntermediate" exact="$targetIsResource and $targetIsProduct"/>
-										<set_value name="$targetIsWareOnly" exact="$targetIsWare and (not $targetIsResource) and (not $targetIsProduct)"/>
+                                        <set_value name="$targetIsResourceOnly" exact="$targetIsResource and (not $targetIsProduct)"/>
+                                        <set_value name="$targetIsProductOnly" exact="(not $targetIsResource) and $targetIsProduct"/>
+                                        <set_value name="$targetIsIntermediate" exact="$targetIsResource and $targetIsProduct"/>
+                                        <set_value name="$targetIsWareOnly" exact="$targetIsWare and (not $targetIsResource) and (not $targetIsProduct)"/>
 
-										<!-- this value is the amount of the trade / target amount. So 1-stocklevel is effectively the current stock level of the target -->
-										<set_value name="$targetStockLevel" exact="$supplyTarget.stocklevel" />
+                                        <!-- this value is the amount of the trade / target amount. So 1-stocklevel is effectively the current stock level of the target -->
+                                        <set_value name="$targetStockLevel" exact="$supplyTarget.stocklevel" />
 
-										<!-- <set_value name="$sourceIsWarehouse" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists and not $supplySource.owner.products.{$supplySource.ware}.exists" /> -->
-										<!-- <set_value name="$targetIsWarehouse" exact="$supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists and not $supplyTarget.owner.products.{$supplyTarget.ware}.exists" /> -->
-										<!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsWareHouse ' +$sourceIsWarehouse" /> -->
-										<!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsWareHouse ' +$targetIsWarehouse" /> -->
-										<!-- how much does the need want? -->
-										<set_value name="$targetOfferedAmount" exact="$supplyTarget.desiredamount" />
-										<!-- how much does the supply have to offer? -->
-										<clamp_trade_amount trade="$supplySource" amount="$supplySource.amount" buyer="this.assignedcontrolled" seller="$supplySource.seller" result="$affordableAmount" />
-										<!-- how much can we haul? -->
-										<set_value name="$cargoHauled" exact="[(this.ship.cargo.{$supplySource.ware}.max)i, this.ship.cargo.{$supplyTarget.ware}.free].min" />
+                                        <!-- <set_value name="$sourceIsWarehouse" exact="$supplySource.owner.tradewares.{$supplySource.ware}.exists and not $supplySource.owner.products.{$supplySource.ware}.exists" /> -->
+                                        <!-- <set_value name="$targetIsWarehouse" exact="$supplyTarget.owner.tradewares.{$supplyTarget.ware}.exists and not $supplyTarget.owner.products.{$supplyTarget.ware}.exists" /> -->
+                                        <!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsWareHouse ' +$sourceIsWarehouse" /> -->
+                                        <!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsWareHouse ' +$targetIsWarehouse" /> -->
+                                        <!-- how much does the need want? -->
+                                        <set_value name="$targetOfferedAmount" exact="$supplyTarget.desiredamount" />
+                                        <!-- how much does the supply have to offer? -->
+                                        <clamp_trade_amount trade="$supplySource" amount="$supplySource.amount" buyer="this.assignedcontrolled" seller="$supplySource.seller" result="$affordableAmount" />
+                                        <!-- how much can we haul? -->
+                                        <set_value name="$cargoHauled" exact="[(this.ship.cargo.{$supplySource.ware}.max)i, this.ship.cargo.{$supplyTarget.ware}.free].min" />
 
-										<!-- the amount for the trade is the minimum of the three amounts -->
-										<set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
+                                        <!-- the amount for the trade is the minimum of the three amounts -->
+                                        <set_value name="$tradeAmount" exact="[$targetOfferedAmount,$affordableAmount,$cargoHauled].min" />
 
-										<!-- $cargoHauled == $targetAmount means it is the last few units needed to finish a station or drones -->
-										<!-- <set_value name="$cargoHauled" exact="[this.ship.cargo.{$supplyTarget.ware}.free,$targetAmount,$supplySource.amount].min" /> -->
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----crazy insane logic block checking'" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  ware ' +$supplyTarget.ware" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  cargoHauled ' +$cargoHauled" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  affordableAmount ' +$affordableAmount" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetOfferedAmount ' +$targetOfferedAmount" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  tradeAmount ' +$tradeAmount" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  allowLowVol ' +$allowLowVol" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsResource ' +$targetIsResource" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsProduct ' +$targetIsProduct" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsWare ' +$targetIsWare" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsResource ' +$sourceIsResource" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsProduct ' +$sourceIsProduct" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsWare ' +$sourceIsWare" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsIntermediate ' +$targetIsIntermediate" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetStockLevel ' +$targetStockLevel" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  continue ' +100*(($targetIsIntermediate) and ($targetStockLevel > 0.7))" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  this.ship.cargo.{$supplyTarget.ware}.max / 1.25 ' +this.ship.cargo.{$supplyTarget.ware}.max / 1.25" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplytargetDesiredAmount ' + $supplyTarget.desiredamount" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplytargetAmount ' + $supplyTarget.amount" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplyTarget owner class ' +$supplyTarget.owner.class" />
-										<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  $supplyTarget.owner.cargo.{$supplyTarget.ware}.target ' +$supplyTarget.owner.cargo.{$supplyTarget.ware}.target" />
+                                        <!-- $cargoHauled == $targetAmount means it is the last few units needed to finish a station or drones -->
+                                        <!-- <set_value name="$cargoHauled" exact="[this.ship.cargo.{$supplyTarget.ware}.free,$targetAmount,$supplySource.amount].min" /> -->
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----crazy insane logic block checking'" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  ware ' +$supplyTarget.ware" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  cargoHauled ' +$cargoHauled" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  affordableAmount ' +$affordableAmount" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetOfferedAmount ' +$targetOfferedAmount" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  tradeAmount ' +$tradeAmount" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  allowLowVol ' +$allowLowVol" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsResource ' +$targetIsResource" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsProduct ' +$targetIsProduct" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsWare ' +$targetIsWare" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsResource ' +$sourceIsResource" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsProduct ' +$sourceIsProduct" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  sourceIsWare ' +$sourceIsWare" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetIsIntermediate ' +$targetIsIntermediate" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  targetStockLevel ' +$targetStockLevel" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  continue ' +100*(($targetIsIntermediate) and ($targetStockLevel > 0.7))" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  this.ship.cargo.{$supplyTarget.ware}.max / 1.25 ' +this.ship.cargo.{$supplyTarget.ware}.max / 1.25" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplytargetDesiredAmount ' + $supplyTarget.desiredamount" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplytargetAmount ' + $supplyTarget.amount" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  supplyTarget owner class ' +$supplyTarget.owner.class" />
+                                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  $supplyTarget.owner.cargo.{$supplyTarget.ware}.target ' +$supplyTarget.owner.cargo.{$supplyTarget.ware}.target" />
 
-										<!-- avoid taking something to the target that it's already creating, if it's over 30% full -->
-										<!-- this tends to happen for workforce related wares -->
-										<continue chance="100*(($targetIsIntermediate) and ($targetStockLevel > 0.7))"/>
+                                        <!-- avoid taking something to the target that it's already creating, if it's over 30% full -->
+                                        <!-- this tends to happen for workforce related wares -->
+                                        <continue chance="100*(($targetIsIntermediate) and ($targetStockLevel > 0.7))"/>
 
-										<do_if value="$tradeAmount gt 0 and ($allowLowVol or $tradeAmount gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($supplyTarget.owner.class == class.buildstorage or $supplySource.owner.cargo.{$supplySource.ware}.target == 0))">
-											<set_value name="$needFound" exact="true" />
-											<create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$tradeAmount" immediate="false" />
-											<create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$tradeAmount" immediate="false" />
-											<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'moving ' +$tradeAmount + ' ' + $supplySource.ware +' from ' +$supplySource.owner.knownname + ' to ' +$supplyTarget.owner.knownname " />
-										</do_if>		
-									</do_if>
-								</do_if>
-							</do_all>
-						</do_if>
-					</do_all>
-				</do_if> <!-- the stations have supply and demand -->
+                                        <do_if value="$tradeAmount gt 0 and ($allowLowVol or $tradeAmount gt (this.ship.cargo.{$supplyTarget.ware}.max / 1.25) or ($supplyTarget.owner.class == class.buildstorage or $supplySource.owner.cargo.{$supplySource.ware}.target == 0))">
+                                            <set_value name="$needFound" exact="true" />
+                                            <create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$tradeAmount" immediate="false" />
+                                            <create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$tradeAmount" immediate="false" />
+                                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'moving ' +$tradeAmount + ' ' + $supplySource.ware +' from ' +$supplySource.owner.knownname + ' to ' +$supplyTarget.owner.knownname " />
+                                        </do_if>		
+                                    </do_if>
+                                </do_if>
+                            </do_all>
+                        </do_if>
+                    </do_all>
+                </do_if> <!-- the stations have supply and demand -->
 
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----after main trade logic block'" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  loop: ' +$loop" />
-				<do_if value="not ($loop ge 3)">
-					<set_value name="$supplies" exact="[]" />
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  resetting supplies list'" />
-				</do_if>
-				<set_value name="$needs" exact="[]" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  resetting needs list'" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'-----after main trade logic block'" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  loop: ' +$loop" />
+                <do_if value="not ($loop ge 3)">
+                    <set_value name="$supplies" exact="[]" />
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  resetting supplies list'" />
+                </do_if>
+                <set_value name="$needs" exact="[]" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'  resetting needs list'" />
 
-				<do_if value="$twoWay and ($loop == 1)">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'--entering two way block'" />
-					<set_value name="$needFound2" exact="$needFound" />
-					<set_value name="$needFound" exact="false" />
-					<set_value name="$supplyFirstLocal" exact="$twoWaySupplyFirst" />
-					<!-- these don't need blacklist filtering because the player picked the stations themselves in the UI, except for potential pathing -->
-					<find_buy_offer tradepartner="this.ship" buyer="$sourceStation" result="$needs" excludeempty="false" multiple="true">
-						<match_buyer>
-							<match_gate_distance object="this.ship" min="0">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-						</match_buyer>
-					</find_buy_offer>
-					<find_sell_offer tradepartner="this.ship" seller="$targetStation" result="$supplies" multiple="true">
-						<match_seller>
-							<match_gate_distance object="$sourceStation" min="0">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-						</match_seller>
-					</find_sell_offer>
-				</do_if>
+                <do_if value="$twoWay and ($loop == 1)">
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="'MulesExtended'" text="'--entering two way block'" />
+                    <set_value name="$needFound2" exact="$needFound" />
+                    <set_value name="$needFound" exact="false" />
+                    <set_value name="$supplyFirstLocal" exact="$twoWaySupplyFirst" />
+                    <!-- these don't need blacklist filtering because the player picked the stations themselves in the UI, except for potential pathing -->
+                    <find_buy_offer tradepartner="this.ship" buyer="$sourceStation" result="$needs" excludeempty="false" multiple="true">
+                        <match_buyer>
+                            <match_gate_distance object="this.ship" min="0">
+                                <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                            </match_gate_distance>
+                        </match_buyer>
+                    </find_buy_offer>
+                    <find_sell_offer tradepartner="this.ship" seller="$targetStation" result="$supplies" multiple="true">
+                        <match_seller>
+                            <match_gate_distance object="$sourceStation" min="0">
+                                <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                            </match_gate_distance>
+                        </match_seller>
+                    </find_sell_offer>
+                </do_if>
 
-				<do_if value="($loop ge 2) and not ($forbidTradeAll or $needFound or $needFound2)">
-					<do_if value="$loop == 2">
-						<set_value name="$supplyFirstLocal" exact="false" />
-						<!-- I believe this trade is intended to be intra-cluster so pathing blacklists may be mostly irrelevant -->
-						<!-- this is checking for player owned stations which need build storage, no blacklist needed -->
-						<find_buy_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$needs" excludeempty="false" multiple="true">
-							<match_buyer>
-								<match_gate_distance object="$sourceStation" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-								<match owner="this.ship.owner" />
-								<match class="class.buildstorage" />
-							</match_buyer>
-						</find_buy_offer>
-						<!-- this is checking for player owned station sells, no blacklist needed except potential pathing -->
-						<find_sell_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$supplies" multiple="true">
-							<match_seller>
-								<match_gate_distance object="this.ship" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-								<match owner="this.ship.owner" />
-							</match_seller>
-						</find_sell_offer>
-						<sort_trades name="$supplies" tradelist="$supplies" sorter="amount" />
-					</do_if>
-					<do_elseif value="$loop == 3">
-						<!-- this is checking for player owned stations which need build storage, no blacklist needed -->
-						<find_buy_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$needs" excludeempty="false" multiple="true">
-							<match_buyer>
-								<match_gate_distance object="$sourceStation" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-								<match owner="this.ship.owner" />
-								<match class="class.buildstorage" negate="true" />
-							</match_buyer>
-						</find_buy_offer>
-					</do_elseif>
-				</do_if>
-			</do_all> <!-- end of main $loops loop-->
+                <do_if value="($loop ge 2) and not ($forbidTradeAll or $needFound or $needFound2)">
+                    <do_if value="$loop == 2">
+                        <set_value name="$supplyFirstLocal" exact="false" />
+                        <!-- I believe this trade is intended to be intra-cluster so pathing blacklists may be mostly irrelevant -->
+                        <!-- this is checking for player owned stations which need build storage, no blacklist needed -->
+                        <find_buy_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$needs" excludeempty="false" multiple="true">
+                            <match_buyer>
+                                <match_gate_distance object="$sourceStation" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                                <match owner="this.ship.owner" />
+                                <match class="class.buildstorage" />
+                            </match_buyer>
+                        </find_buy_offer>
+                        <!-- this is checking for player owned station sells, no blacklist needed except potential pathing -->
+                        <find_sell_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$supplies" multiple="true">
+                            <match_seller>
+                                <match_gate_distance object="this.ship" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                                <match owner="this.ship.owner" />
+                            </match_seller>
+                        </find_sell_offer>
+                        <sort_trades name="$supplies" tradelist="$supplies" sorter="amount" />
+                    </do_if>
+                    <do_elseif value="$loop == 3">
+                        <!-- this is checking for player owned stations which need build storage, no blacklist needed -->
+                        <find_buy_offer tradepartner="this.ship" space="$sourceStation.cluster" result="$needs" excludeempty="false" multiple="true">
+                            <match_buyer>
+                                <match_gate_distance object="$sourceStation" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                                <match owner="this.ship.owner" />
+                                <match class="class.buildstorage" negate="true" />
+                            </match_buyer>
+                        </find_buy_offer>
+                    </do_elseif>
+                </do_if>
+            </do_all> <!-- end of main $loops loop-->
 
-			<remove_value name="$supplyTarget" />
-			<remove_value name="$supplySource" />
-			<remove_value name="$supplies" />
-			<remove_value name="$needs" />
-			<remove_value name="$tradeNeeds" />
-			<remove_value name="$stationNeeds" />
-			<remove_value name="$innerList" />
-			<remove_value name="$outerList" />
+            <remove_value name="$supplyTarget" />
+            <remove_value name="$supplySource" />
+            <remove_value name="$supplies" />
+            <remove_value name="$needs" />
+            <remove_value name="$tradeNeeds" />
+            <remove_value name="$stationNeeds" />
+            <remove_value name="$innerList" />
+            <remove_value name="$outerList" />
 
-			<label name="endWait" />
-			<wait min="3min" max="5min" />
-			<label name="end" />
+            <label name="endWait" />
+            <wait min="3min" max="5min" />
+            <label name="end" />
 
-		</actions>
-	</attention>
+        </actions>
+    </attention>
 </aiscript>

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -1,609 +1,609 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <aiscript name="supplymule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="5">
-	<!-- Setup context menu order-->
-	<order id="SupplyMule" name="{61552,4001}" description="{61552,4101}" category="trade" infinite="true">
-		<params>
-			<!-- menu option: Home (Define Home)-->
-			<param name="home" type="object" default="this.ship.sector" text="{61552,4002}" comment="{61552,4102}">
-				<input_param name="class" value="[class.ship, class.station, class.sector]" />
-				<patch sinceversion="2" value="if $sourceStation then $sourceStation else this.ship.sector"/>
-			</param>
-			<!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.)-->
-			<param name="assignHome" type="bool" default="false" text="{61552,4003}" comment="{61552,4103}">
-				<patch sinceversion="2" value="$assignSrc"/>
-			</param>
-			<!-- menu option: Max Distance (Maximum Jumpes to buy/sell, in case of ai service only buy)-->
-			<param name="maxDist" required="false" default="this.ship.pilot.skill.piloting * 2" type="number" text="{61552,4004}" comment="{61552,4104}">
-				<input_param name="startvalue" value="this.ship.pilot.skill.piloting * 2" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="this.ship.pilot.skill.piloting * 2" />
-				<input_param name="step" value="1" />
-			</param>
-			<!-- menu option: Serve Source Only (will only serve the source station if used)-->
-			<param name="dedicatedServe" type="bool" default="false" text="{61552,4005}" comment="{61552,4105}" />
-			<!-- menu option: include player and/or ai stations as sources for supplies -->
-			<param name="allowPlayerSuppliers" type="bool" default="true" text="{61552,4006}" comment="{61552,4106}">
-				<patch sinceversion="2" value="true"/>
-			</param>
-			<param name="allowAiSuppliers"     type="bool" default="true" text="{61552,4007}"     comment="{61552,4107}">
-				<patch sinceversion="2" value="not $tradeWithOwn"/>
-			</param>
+    <!-- Setup context menu order-->
+    <order id="SupplyMule" name="{61552,4001}" description="{61552,4101}" category="trade" infinite="true">
+        <params>
+            <!-- menu option: Home (Define Home)-->
+            <param name="home" type="object" default="this.ship.sector" text="{61552,4002}" comment="{61552,4102}">
+                <input_param name="class" value="[class.ship, class.station, class.sector]" />
+                <patch sinceversion="2" value="if $sourceStation then $sourceStation else this.ship.sector"/>
+            </param>
+            <!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.)-->
+            <param name="assignHome" type="bool" default="false" text="{61552,4003}" comment="{61552,4103}">
+                <patch sinceversion="2" value="$assignSrc"/>
+            </param>
+            <!-- menu option: Max Distance (Maximum Jumpes to buy/sell, in case of ai service only buy)-->
+            <param name="maxDist" required="false" default="this.ship.pilot.skill.piloting * 2" type="number" text="{61552,4004}" comment="{61552,4104}">
+                <input_param name="startvalue" value="this.ship.pilot.skill.piloting * 2" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="this.ship.pilot.skill.piloting * 2" />
+                <input_param name="step" value="1" />
+            </param>
+            <!-- menu option: Serve Source Only (will only serve the source station if used)-->
+            <param name="dedicatedServe" type="bool" default="false" text="{61552,4005}" comment="{61552,4105}" />
+            <!-- menu option: include player and/or ai stations as sources for supplies -->
+            <param name="allowPlayerSuppliers" type="bool" default="true" text="{61552,4006}" comment="{61552,4106}">
+                <patch sinceversion="2" value="true"/>
+            </param>
+            <param name="allowAiSuppliers"     type="bool" default="true" text="{61552,4007}"     comment="{61552,4107}">
+                <patch sinceversion="2" value="not $tradeWithOwn"/>
+            </param>
 
-			<!-- menu option: include buildstorage, resources, intermediates, and tradewares as possible options to supply -->
-			<param name="allowBuildstorage"  type="bool" default="true" text="{61552,4008}"  comment="{61552,4108}">
-				<patch sinceversion="2" value="not $producer"/>
-			</param>
-			<param name="allowResources"     type="bool" default="true" text="{61552,4009}"     comment="{61552,4109}">
-				<patch sinceversion="2" value="not $builder"/>
-			</param>
-			<param name="allowIntermediates" type="bool" default="true" text="{61552,4010}" comment="{61552,4110}">
-				<patch sinceversion="2" value="not $builder"/>
-			</param>
-			<param name="allowTradewares"    type="bool" default="true" text="{61552,4011}"    comment="{61552,4111}">
-				<patch sinceversion="2" value="not $builder"/>
-			</param>
+            <!-- menu option: include buildstorage, resources, intermediates, and tradewares as possible options to supply -->
+            <param name="allowBuildstorage"  type="bool" default="true" text="{61552,4008}"  comment="{61552,4108}">
+                <patch sinceversion="2" value="not $producer"/>
+            </param>
+            <param name="allowResources"     type="bool" default="true" text="{61552,4009}"     comment="{61552,4109}">
+                <patch sinceversion="2" value="not $builder"/>
+            </param>
+            <param name="allowIntermediates" type="bool" default="true" text="{61552,4010}" comment="{61552,4110}">
+                <patch sinceversion="2" value="not $builder"/>
+            </param>
+            <param name="allowTradewares"    type="bool" default="true" text="{61552,4011}"    comment="{61552,4111}">
+                <patch sinceversion="2" value="not $builder"/>
+            </param>
 
-			<!-- lock wares to player selection -->
-			<param name="lockWares"            type="bool" default="false" text="{61552,4012}" comment="{61552,4112}" />
+            <!-- lock wares to player selection -->
+            <param name="lockWares"            type="bool" default="false" text="{61552,4012}" comment="{61552,4112}" />
 
-			<!-- menu option: WareBasket List-->
-			<param name="specialWareBasket"    type="list" default="[]"    text="{61552,4013}"       comment="{61552,4113}">
-				<input_param name="type"     value="'ware'" />
-				<input_param name="cancarry" value="this.ship" />
-			</param>
+            <!-- menu option: WareBasket List-->
+            <param name="specialWareBasket"    type="list" default="[]"    text="{61552,4013}"       comment="{61552,4113}">
+                <input_param name="type"     value="'ware'" />
+                <input_param name="cancarry" value="this.ship" />
+            </param>
 
-			<!-- menu option: Max Trades (Maximum trades per buy run)-->
-			<param name="maxTrades" required="false" default="1" type="number" text="{61552,4014}" comment="{61552,4114}">
-				<input_param name="startvalue" value="1" />
-				<input_param name="min" value="1" />
-				<input_param name="max" value="1" />
-				<input_param name="step" value="1" />
-				<patch sinceversion="2" value="$maxtrades"/>
-			</param>
+            <!-- menu option: Max Trades (Maximum trades per buy run)-->
+            <param name="maxTrades" required="false" default="1" type="number" text="{61552,4014}" comment="{61552,4114}">
+                <input_param name="startvalue" value="1" />
+                <input_param name="min" value="1" />
+                <input_param name="max" value="1" />
+                <input_param name="step" value="1" />
+                <patch sinceversion="2" value="$maxtrades"/>
+            </param>
 
-			<param name="minCargoUsed" default="75" type="number" text="{61552,4022}" comment="{61552,4122}">
-				<input_param name="startvalue" value="75" />
-				<input_param name="min" value="25" />
-				<input_param name="max" value="95" />
-				<input_param name="step" value="5" />
-				<patch sinceversion="4" value="75"/>
-			</param>
+            <param name="minCargoUsed" default="75" type="number" text="{61552,4022}" comment="{61552,4122}">
+                <input_param name="startvalue" value="75" />
+                <input_param name="min" value="25" />
+                <input_param name="max" value="95" />
+                <input_param name="step" value="5" />
+                <patch sinceversion="4" value="75"/>
+            </param>
 
-			<!-- menu option: Profit Override Percentage (Used when buying/selling at own warehouses mostly) -->
-			<param name="playerBuyMod" default="100" type="number" text="{61552,4015}" comment="{61552,4115}">
-				<input_param name="startvalue" value="100" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="100" />
-				<input_param name="step" value="5" />
-			</param>
+            <!-- menu option: Profit Override Percentage (Used when buying/selling at own warehouses mostly) -->
+            <param name="playerBuyMod" default="100" type="number" text="{61552,4015}" comment="{61552,4115}">
+                <input_param name="startvalue" value="100" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="100" />
+                <input_param name="step" value="5" />
+            </param>
 
-			<!-- Internal parameter used to restart the script on version update if required -->
-			<param name="restartScript" type="internal" default="false"/>
-			<!-- Old deprecated parameters, see patch version 2 below -->
-			<param name="tradeWithOwn"  type="internal" default="null" text="{61552,4016}" comment="{61552,4116}" />
-			<param name="builder"       type="internal" default="null" text="{61552,4017}"    comment="{61552,4117}" />
-			<param name="producer"      type="internal" default="null" text="{61552,4018}"   comment="{61552,4118}" />
-			<param name="sourceStation" type="internal" default="null" text="{61552,4019}"   comment="{61552,4119}"/>
-			<param name="assignSrc"     type="internal" default="false" text="{61552,4020}" comment="{61552,4120}" />
-			<param name="maxtrades"     type="internal" required="false" default="5" text="{61552,4021}" comment="{61552,4121}"/>
-		</params>
-		<requires>
-			<match shiptype="shiptype.lasertower" negate="true" />
-			<!-- no idea wtf this is for-->
-		</requires>
-	</order>
-
-
-	<interrupts>
-		<handler ref="SectorChangeHandler" />
-		<handler ref="AttackHandler" />
-		<handler ref="MissileLockHandler" />
-		<handler ref="ScannedHandler" />
-		<handler ref="InspectedHandler" />
-		<handler ref="FoundAbandonedHandler" />
-		<handler ref="ResupplyHandler" />
-		<handler ref="JobRemoveRequestHandler" />
-		<handler ref="TargetInvalidHandler" />
-	</interrupts>
-
-	<init>
-		<!-- debug settings -->
-		<set_value name="$debugchance" exact="100" />
-		<set_value name="$debugFileName" exact="'SupplyMule - ' + this.ship.idcode"/>
-		<set_value name="$debugDirName" exact="'MulesExtended'"/>
-
-		<!-- init section for mule script -->
-		<set_value name="$logbookEntryTitle" exact="'SupplyMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
-		<set_order_syncpoint_reached order="this.ship.order" />
-		<set_command_action commandaction="commandaction.searchingtrades" />
-		<!-- Set commander -->
-		<do_if value="$home and ($home.owner == this.ship.owner) and $assignHome">
-			<set_object_commander object="this.ship" commander="$home" assignment="assignment.trade" />
-		</do_if>
-	</init>
-
-	<patch sinceversion="5">
-		<!-- This will reissue any standing supply mule orders -->
-		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
-		<debug_text text="'PATCH: Restarting supply mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
-		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
-	</patch>
-	<patch sinceversion="3">
-		<!-- force maxTrades to 1 since it doesn't work, and will reduce efficiency at non-1 values -->
-		<debug_text text="'PATCH: Setting maxTrades=1 for supply mule %s'.[this.ship.idcode]" filter="savegame"/>
-		<edit_order_param order="this.assignedcontrolled.order" param="'maxTrades'" value="1"/>
-	</patch>
-
-	<attention min="unknown">
-		<actions>
-			<label name="start" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ScriptStart'" append="false"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'AssignedControlled: %s (%s) - %s'.[this.assignedcontrolled.knownname, this.assignedcontrolled.idcode, this.assignedcontrolled]" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Entity (this): %s'.[this]"/>
-
-			<!-- Dump Mule Settings -->
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Supply Mule Settings:'"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    Home: %s (%s)'.[$home.knownname,@$home.idcode]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    assignHome: %s'.[$assignHome]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    maxDist: %s'.[$maxDist]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    dedicatedServe: %s'.[$dedicatedServe]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowPlayerSuppliers: %s'.[$allowPlayerSuppliers]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowAiSuppliers: %s'.[$allowAiSuppliers]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowBuildstorage: %s'.[$allowBuildstorage]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowResources: %s'.[$allowResources]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowIntermediates: %s'.[$allowIntermediates]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowTradewares: %s'.[$allowTradewares]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    lockWares: %s'.[$lockWares]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    specialWareBasket: %s'.[$specialWareBasket]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    maxTrades: %s'.[$maxTrades]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    minCargoUsed: %s'.[$minCargoUsed]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    playerBuyMod: %s'.[$playerBuyMod]"/>
-
-			<do_if value="$assignHome and $home.isclass.sector">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Invalid Config: assignHome (No Station or Ship configured)'"/>
-				<set_value name="$assignHome" exact="false" />
-			</do_if>
-
-			<!-- Setup variables for later use-->
-			<!-- Create shotcuts for all ai and all player factions -->
-			<!-- TODO: Check how ventures work an remove visitor factions depending on the outcome. -->
-			<get_factions_by_relation relation="dock" result="$aiFactions" object="this.ship"/>
-			<remove_from_list name="$aiFactions" exact="faction.player"/>
-			<set_value name="$playerFactions" exact="[faction.player]"/>
-
-			<!-- Determine where we assigned to -->
-			<set_value name="$homeStationOrShip" exact="if ($home.isclass.{[class.ship, class.station]}) then $home else null"/>
-			<set_value name="$homeSector" exact="if ($home.isclass.sector) then $home else $home.sector"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Home Station or Ship: %s'.[if $homeStationOrShip then $homeStationOrShip.knownname else '-',if $homeStationOrShip then $homeStationOrShip.idcode else '-']"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Home Sector: %s'.[$homeSector.knownname]"/>
+            <!-- Internal parameter used to restart the script on version update if required -->
+            <param name="restartScript" type="internal" default="false"/>
+            <!-- Old deprecated parameters, see patch version 2 below -->
+            <param name="tradeWithOwn"  type="internal" default="null" text="{61552,4016}" comment="{61552,4116}" />
+            <param name="builder"       type="internal" default="null" text="{61552,4017}"    comment="{61552,4117}" />
+            <param name="producer"      type="internal" default="null" text="{61552,4018}"   comment="{61552,4118}" />
+            <param name="sourceStation" type="internal" default="null" text="{61552,4019}"   comment="{61552,4119}"/>
+            <param name="assignSrc"     type="internal" default="false" text="{61552,4020}" comment="{61552,4120}" />
+            <param name="maxtrades"     type="internal" required="false" default="5" text="{61552,4021}" comment="{61552,4121}"/>
+        </params>
+        <requires>
+            <match shiptype="shiptype.lasertower" negate="true" />
+            <!-- no idea wtf this is for-->
+        </requires>
+    </order>
 
 
-			<!--here we want to copy settings to subordinates-->
-			<set_value name="$subordinateShipCopyType" exact="[shiptype.courier, shiptype.transporter, shiptype.freighter, shiptype.miner, shiptype.largeminer, this.ship.type]"/>
-			<do_for_each name="$subordinate" in="this.ship.subordinates">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Subordinates %s'.[$subordinate.knownname]"/>
-				<do_if value="not $subordinateShipCopyType.indexof.{$subordinate.type}">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    not copying settings, because of wrong shiptype: %s'.[$subordinate.type]"/>
-					<continue />
-				</do_if>
-				<do_if value="global.$v1024cf_mod_loaded?" comment="Checking that this value exists; true if Civilian Fleets is loaded.">
-					<!-- Civilian Fleets loaded. -->
-					<!-- Check also, where Civ-Fleet is loaded but the user is not using the Civ-Fleet Supply Mules fleet -->
-					<do_if value="$subordinate.assignment == assignment.trade" comment="Checking if the Mule is being handled by Civ-Fleets, that is the characteristic property.">
-						<!-- Skip the handling on this side, stay in the fleet, and let Civilian Fleets handle the order sync. -->
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    is handled by Civilian Fleets; skipping'" output="false" append="true" />
-						<continue />
-					</do_if>
-				</do_if>
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    copying default behavior'"/>
+    <interrupts>
+        <handler ref="SectorChangeHandler" />
+        <handler ref="AttackHandler" />
+        <handler ref="MissileLockHandler" />
+        <handler ref="ScannedHandler" />
+        <handler ref="InspectedHandler" />
+        <handler ref="FoundAbandonedHandler" />
+        <handler ref="ResupplyHandler" />
+        <handler ref="JobRemoveRequestHandler" />
+        <handler ref="TargetInvalidHandler" />
+    </interrupts>
+
+    <init>
+        <!-- debug settings -->
+        <set_value name="$debugchance" exact="100" />
+        <set_value name="$debugFileName" exact="'SupplyMule - ' + this.ship.idcode"/>
+        <set_value name="$debugDirName" exact="'MulesExtended'"/>
+
+        <!-- init section for mule script -->
+        <set_value name="$logbookEntryTitle" exact="'SupplyMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
+        <set_order_syncpoint_reached order="this.ship.order" />
+        <set_command_action commandaction="commandaction.searchingtrades" />
+        <!-- Set commander -->
+        <do_if value="$home and ($home.owner == this.ship.owner) and $assignHome">
+            <set_object_commander object="this.ship" commander="$home" assignment="assignment.trade" />
+        </do_if>
+    </init>
+
+    <patch sinceversion="5">
+        <!-- This will reissue any standing supply mule orders -->
+        <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+        <debug_text text="'PATCH: Restarting supply mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
+        <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
+    </patch>
+    <patch sinceversion="3">
+        <!-- force maxTrades to 1 since it doesn't work, and will reduce efficiency at non-1 values -->
+        <debug_text text="'PATCH: Setting maxTrades=1 for supply mule %s'.[this.ship.idcode]" filter="savegame"/>
+        <edit_order_param order="this.assignedcontrolled.order" param="'maxTrades'" value="1"/>
+    </patch>
+
+    <attention min="unknown">
+        <actions>
+            <label name="start" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ScriptStart'" append="false"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'AssignedControlled: %s (%s) - %s'.[this.assignedcontrolled.knownname, this.assignedcontrolled.idcode, this.assignedcontrolled]" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Entity (this): %s'.[this]"/>
+
+            <!-- Dump Mule Settings -->
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Supply Mule Settings:'"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    Home: %s (%s)'.[$home.knownname,@$home.idcode]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    assignHome: %s'.[$assignHome]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    maxDist: %s'.[$maxDist]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    dedicatedServe: %s'.[$dedicatedServe]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowPlayerSuppliers: %s'.[$allowPlayerSuppliers]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowAiSuppliers: %s'.[$allowAiSuppliers]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowBuildstorage: %s'.[$allowBuildstorage]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowResources: %s'.[$allowResources]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowIntermediates: %s'.[$allowIntermediates]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    allowTradewares: %s'.[$allowTradewares]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    lockWares: %s'.[$lockWares]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    specialWareBasket: %s'.[$specialWareBasket]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    maxTrades: %s'.[$maxTrades]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    minCargoUsed: %s'.[$minCargoUsed]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    playerBuyMod: %s'.[$playerBuyMod]"/>
+
+            <do_if value="$assignHome and $home.isclass.sector">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Invalid Config: assignHome (No Station or Ship configured)'"/>
+                <set_value name="$assignHome" exact="false" />
+            </do_if>
+
+            <!-- Setup variables for later use-->
+            <!-- Create shotcuts for all ai and all player factions -->
+            <!-- TODO: Check how ventures work an remove visitor factions depending on the outcome. -->
+            <get_factions_by_relation relation="dock" result="$aiFactions" object="this.ship"/>
+            <remove_from_list name="$aiFactions" exact="faction.player"/>
+            <set_value name="$playerFactions" exact="[faction.player]"/>
+
+            <!-- Determine where we assigned to -->
+            <set_value name="$homeStationOrShip" exact="if ($home.isclass.{[class.ship, class.station]}) then $home else null"/>
+            <set_value name="$homeSector" exact="if ($home.isclass.sector) then $home else $home.sector"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Home Station or Ship: %s'.[if $homeStationOrShip then $homeStationOrShip.knownname else '-',if $homeStationOrShip then $homeStationOrShip.idcode else '-']"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Home Sector: %s'.[$homeSector.knownname]"/>
+
+
+            <!--here we want to copy settings to subordinates-->
+            <set_value name="$subordinateShipCopyType" exact="[shiptype.courier, shiptype.transporter, shiptype.freighter, shiptype.miner, shiptype.largeminer, this.ship.type]"/>
+            <do_for_each name="$subordinate" in="this.ship.subordinates">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Subordinates %s'.[$subordinate.knownname]"/>
+                <do_if value="not $subordinateShipCopyType.indexof.{$subordinate.type}">
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    not copying settings, because of wrong shiptype: %s'.[$subordinate.type]"/>
+                    <continue />
+                </do_if>
+                <do_if value="global.$v1024cf_mod_loaded?" comment="Checking that this value exists; true if Civilian Fleets is loaded.">
+                    <!-- Civilian Fleets loaded. -->
+                    <!-- Check also, where Civ-Fleet is loaded but the user is not using the Civ-Fleet Supply Mules fleet -->
+                    <do_if value="$subordinate.assignment == assignment.trade" comment="Checking if the Mule is being handled by Civ-Fleets, that is the characteristic property.">
+                        <!-- Skip the handling on this side, stay in the fleet, and let Civilian Fleets handle the order sync. -->
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    is handled by Civilian Fleets; skipping'" output="false" append="true" />
+                        <continue />
+                    </do_if>
+                </do_if>
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    copying default behavior'"/>
 <!--				<remove_object_commander object="$subordinate" />-->
-				<create_order object="$subordinate" default="true" id="'SupplyMule'">
-					<!-- Note: we changed the default orders, therefore civilian fleets needs an update -->
-					<param name="home" value="$home" />
-					<param name="maxDist" value="[$subordinate.pilot.skill.piloting * 2, $maxDist].min" />
-					<param name="assignHome" value="false" />
-					<param name="dedicatedServe" value="$dedicatedServe" />
-					<param name="allowPlayerSuppliers" value="$allowPlayerSuppliers" />
-					<param name="allowAiSuppliers" value="$allowAiSuppliers" />
-					<param name="allowBuildstorage" value="$allowBuildstorage" />
-					<param name="allowResources" value="$allowResources" />
-					<param name="allowIntermediates" value="$allowIntermediates" />
-					<param name="allowTradewares" value="$allowTradewares" />
-					<param name="lockWares" value="$lockWares" />
-					<param name="specialWareBasket" value="$specialWareBasket" />
-					<param name="maxTrades" value="$maxTrades" />
-					<param name="playerBuyMod" value="$playerBuyMod" />
-					<param name="minCargoUsed" value="$minCargoUsed" />
-				</create_order>
-				<wait min="50ms" max="150ms" />
-			</do_for_each>
+                <create_order object="$subordinate" default="true" id="'SupplyMule'">
+                    <!-- Note: we changed the default orders, therefore civilian fleets needs an update -->
+                    <param name="home" value="$home" />
+                    <param name="maxDist" value="[$subordinate.pilot.skill.piloting * 2, $maxDist].min" />
+                    <param name="assignHome" value="false" />
+                    <param name="dedicatedServe" value="$dedicatedServe" />
+                    <param name="allowPlayerSuppliers" value="$allowPlayerSuppliers" />
+                    <param name="allowAiSuppliers" value="$allowAiSuppliers" />
+                    <param name="allowBuildstorage" value="$allowBuildstorage" />
+                    <param name="allowResources" value="$allowResources" />
+                    <param name="allowIntermediates" value="$allowIntermediates" />
+                    <param name="allowTradewares" value="$allowTradewares" />
+                    <param name="lockWares" value="$lockWares" />
+                    <param name="specialWareBasket" value="$specialWareBasket" />
+                    <param name="maxTrades" value="$maxTrades" />
+                    <param name="playerBuyMod" value="$playerBuyMod" />
+                    <param name="minCargoUsed" value="$minCargoUsed" />
+                </create_order>
+                <wait min="50ms" max="150ms" />
+            </do_for_each>
 
-			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
-			<set_value name="$cargo" exact="this.ship.cargo.list" />
+            <!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
+            <set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_if value="$cargo.count gt 0">
-				<run_script name="'mule.lib.empty_cargo'">
-					<param name="debugchance" value="$debugchance" />
-					<param name="debugFileName" value="$debugFileName" />
-					<param name="debugDirName" value="$debugDirName" />
-					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
-					<param name="cargo" value="$cargo" />
-				</run_script>
-			</do_if>
+            <do_if value="$cargo.count gt 0">
+                <run_script name="'mule.lib.empty_cargo'">
+                    <param name="debugchance" value="$debugchance" />
+                    <param name="debugFileName" value="$debugFileName" />
+                    <param name="debugDirName" value="$debugDirName" />
+                    <param name="logbookEntryTitle" value="$logbookEntryTitle" />
+                    <param name="cargo" value="$cargo" />
+                </run_script>
+            </do_if>
 
-			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />
-				<wait min="50ms" max="150ms" />
-				<resume label="start" />
-			</do_if>
+            <do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />
+                <wait min="50ms" max="150ms" />
+                <resume label="start" />
+            </do_if>
 
-			<!-- Create shotcuts for all wares that could be used in searches -->
-			<set_value           chance="100*$lockWares" name="$allowedWares" exact="$specialWareBasket"/>
-			<get_ware_definition chance="100*(not $lockWares)" result="$allowedWares" flags="economy" />
+            <!-- Create shotcuts for all wares that could be used in searches -->
+            <set_value           chance="100*$lockWares" name="$allowedWares" exact="$specialWareBasket"/>
+            <get_ware_definition chance="100*(not $lockWares)" result="$allowedWares" flags="economy" />
 
-			<!-- Create a list of prorities for our mule -->
-			<!-- It's an ordered tasklist of what out mule should try to do first  -->
-			<create_list name="$prioritylist" />
-			<!-- ************************ supply mule logic ************************ -->
-			<!-- Serve order
-				if player station
-   					serve player station
-   					serve player sector
-					serve player area
-				if ai station
-   					serve ai station
-   					serve ai sector
-				if sector
-   					serve player sector
-   					serve player area
-   			-->
-			<!-- Dedicated serve: only serve assigned home, whether its a station or sector -->
-			<!-- Serve order: buildstorage -> resources -> intermediates -> tradewares -->
-			<!-- Dedicated player's builder mode. Activated by: * selected allow build storage only; * selected station or sector as home. When active - an evaluation of trade offers is perfomed by a fill level algorithm instead of a best profit. -->
+            <!-- Create a list of prorities for our mule -->
+            <!-- It's an ordered tasklist of what out mule should try to do first  -->
+            <create_list name="$prioritylist" />
+            <!-- ************************ supply mule logic ************************ -->
+            <!-- Serve order
+                if player station
+                       serve player station
+                       serve player sector
+                    serve player area
+                if ai station
+                       serve ai station
+                       serve ai sector
+                if sector
+                       serve player sector
+                       serve player area
+               -->
+            <!-- Dedicated serve: only serve assigned home, whether its a station or sector -->
+            <!-- Serve order: buildstorage -> resources -> intermediates -> tradewares -->
+            <!-- Dedicated player's builder mode. Activated by: * selected allow build storage only; * selected station or sector as home. When active - an evaluation of trade offers is perfomed by a fill level algorithm instead of a best profit. -->
 
-			<!-- $supplierFactions: list of factions -->
-			<!-- $serve: 'station', 'sector', 'area' -->
-			<!-- $type: 'buildstorage', 'tradewares', 'resources', 'products' -->
-			<!-- Cases: -->
+            <!-- $supplierFactions: list of factions -->
+            <!-- $serve: 'station', 'sector', 'area' -->
+            <!-- $type: 'buildstorage', 'tradewares', 'resources', 'products' -->
+            <!-- Cases: -->
 
-			<set_value name="$isServingStationOrShip" exact="if ($homeStationOrShip != null) then true else false"/>
-			<set_value name="$isServingSector" exact="if (($home.isclass.sector and $dedicatedServe) or ($home.isclass.{[class.ship, class.station]} and not $dedicatedServe)) then true else false"/>
-			<set_value name="$isServingPlayer" exact="(not $isServingStationOrShip) or ($homeStationOrShip.owner == faction.player)" />
-			<set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions else $aiFactions" />
-			<set_value name="$isServingArea" exact="$isServingPlayer and (not $dedicatedServe)" />
-			<set_value name="$isDedicatedPlayerBuilder" exact="$isServingPlayer and $allowBuildstorage and (not $allowResources) and (not $allowIntermediates) and (not $allowTradewares)" />
+            <set_value name="$isServingStationOrShip" exact="if ($homeStationOrShip != null) then true else false"/>
+            <set_value name="$isServingSector" exact="if (($home.isclass.sector and $dedicatedServe) or ($home.isclass.{[class.ship, class.station]} and not $dedicatedServe)) then true else false"/>
+            <set_value name="$isServingPlayer" exact="(not $isServingStationOrShip) or ($homeStationOrShip.owner == faction.player)" />
+            <set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions else $aiFactions" />
+            <set_value name="$isServingArea" exact="$isServingPlayer and (not $dedicatedServe)" />
+            <set_value name="$isDedicatedPlayerBuilder" exact="$isServingPlayer and $allowBuildstorage and (not $allowResources) and (not $allowIntermediates) and (not $allowTradewares)" />
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingStationOrShip: %s'.[$isServingStationOrShip]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingSector: %s'.[$isServingSector]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingPlayer: %s'.[$isServingPlayer]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    serveFactions: %s'.[$serveFactions]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingArea: %s'.[$isServingArea]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isDedicatedPlayerBuilder: %s'.[$isDedicatedPlayerBuilder]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingStationOrShip: %s'.[$isServingStationOrShip]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingSector: %s'.[$isServingSector]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingPlayer: %s'.[$isServingPlayer]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    serveFactions: %s'.[$serveFactions]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isServingArea: %s'.[$isServingArea]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'    isDedicatedPlayerBuilder: %s'.[$isDedicatedPlayerBuilder]"/>
 
-			<do_if value="$isServingStationOrShip">
-				<!-- Serve Station -->
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'tradewares' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'tradewares' ]" />
-			</do_if>
+            <do_if value="$isServingStationOrShip">
+                <!-- Serve Station -->
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'stationOrShip', $type = 'tradewares' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'stationOrShip', $type = 'tradewares' ]" />
+            </do_if>
 
-			<!-- Serve Sector -->
-			<do_if value="$isServingSector">
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'tradewares' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'tradewares' ]" />
-			</do_if>
+            <!-- Serve Sector -->
+            <do_if value="$isServingSector">
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'sector', $type = 'tradewares' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'sector', $type = 'tradewares' ]" />
+            </do_if>
 
-			<do_if value="$isServingArea">
-				<!-- Serve player area -->
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'buildstorage' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'resources' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'intermediates' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'tradewares' ]" />
-				<append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'tradewares' ]" />
-			</do_if>
+            <do_if value="$isServingArea">
+                <!-- Serve player area -->
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'buildstorage' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'resources' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'intermediates' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $playerFactions, $serve = 'area', $type = 'tradewares' ]" />
+                <append_to_list name="$prioritylist" exact="table[ $supplierFactions = $aiFactions,     $serve = 'area', $type = 'tradewares' ]" />
+            </do_if>
 
-			<!-- Apply filters selected by the user in the ui -->
-			<create_list name="$filteredPrioritylist" />
-			<do_for_each name="$priority" in="$prioritylist">
-				<!-- Basically, we prevent every prioirty that does not match our criteria from going onto the $filteredPrioritylist -->
-				<continue chance="100*((not $allowBuildstorage)  and ($priority.$type == 'buildstorage'))"/>
-				<continue chance="100*((not $allowResources)     and ($priority.$type == 'resources'))"/>
-				<continue chance="100*((not $allowIntermediates) and ($priority.$type == 'intermediates'))"/>
-				<continue chance="100*((not $allowTradewares)    and ($priority.$type == 'tradewares'))"/>
+            <!-- Apply filters selected by the user in the ui -->
+            <create_list name="$filteredPrioritylist" />
+            <do_for_each name="$priority" in="$prioritylist">
+                <!-- Basically, we prevent every prioirty that does not match our criteria from going onto the $filteredPrioritylist -->
+                <continue chance="100*((not $allowBuildstorage)  and ($priority.$type == 'buildstorage'))"/>
+                <continue chance="100*((not $allowResources)     and ($priority.$type == 'resources'))"/>
+                <continue chance="100*((not $allowIntermediates) and ($priority.$type == 'intermediates'))"/>
+                <continue chance="100*((not $allowTradewares)    and ($priority.$type == 'tradewares'))"/>
 
-				<!-- Filter supplier factions -->
-				<remove_from_list chance="100*(not $allowPlayerSuppliers)" name="$priority.$supplierFactions" list="$playerFactions"/>
-				<remove_from_list chance="100*(not $allowAiSuppliers)" name="$priority.$supplierFactions" list="$aiFactions"/>
-				<continue chance="100*($priority.$supplierFactions.count == 0)"/>
+                <!-- Filter supplier factions -->
+                <remove_from_list chance="100*(not $allowPlayerSuppliers)" name="$priority.$supplierFactions" list="$playerFactions"/>
+                <remove_from_list chance="100*(not $allowAiSuppliers)" name="$priority.$supplierFactions" list="$aiFactions"/>
+                <continue chance="100*($priority.$supplierFactions.count == 0)"/>
 
-				<!-- If the have passed all filters, add to filtered list -->
-				<append_to_list name="$filteredPrioritylist" exact="$priority"/>
-			</do_for_each>
+                <!-- If the have passed all filters, add to filtered list -->
+                <append_to_list name="$filteredPrioritylist" exact="$priority"/>
+            </do_for_each>
 
-			<!-- station that is currently served (determined by the first set of orders issued) -->
-			<set_value name="$alreadyServing" exact="null"/>
-			<!-- Current number of issued trades -->
-			<set_value name="$tradeCount" exact="0"/>
+            <!-- station that is currently served (determined by the first set of orders issued) -->
+            <set_value name="$alreadyServing" exact="null"/>
+            <!-- Current number of issued trades -->
+            <set_value name="$tradeCount" exact="0"/>
 
-			<!-- ************************ main loop ************************-->
-			<!-- Start looping over our prioritiylist to determine what to do-->
-			<do_for_each name="$priority" in="$filteredPrioritylist">
-				<!-- If we were already serving a station, but would require to serve a different station to fill our cargo, abort -->
-				<do_if value="($alreadyServing and $alreadyServing.$serve != $priority.$serve)">
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Search finished. No more trade at station found.'" />
-					<break/>
-				</do_if>
+            <!-- ************************ main loop ************************-->
+            <!-- Start looping over our prioritiylist to determine what to do-->
+            <do_for_each name="$priority" in="$filteredPrioritylist">
+                <!-- If we were already serving a station, but would require to serve a different station to fill our cargo, abort -->
+                <do_if value="($alreadyServing and $alreadyServing.$serve != $priority.$serve)">
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Search finished. No more trade at station found.'" />
+                    <break/>
+                </do_if>
 
-				<!-- Print current priority to debuglog -->
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Current priority is to supply &quot;%s&quot; by buying &quot;%s&quot; from &quot;%s&quot;'.[$priority.$serve, $priority.$type, if ($priority.$supplierFactions == $playerFactions) then 'player' else 'ai']" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'------------------------------------------------------------------------------------------------------------------------------------'" />
+                <!-- Print current priority to debuglog -->
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Current priority is to supply &quot;%s&quot; by buying &quot;%s&quot; from &quot;%s&quot;'.[$priority.$serve, $priority.$type, if ($priority.$supplierFactions == $playerFactions) then 'player' else 'ai']" />
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'------------------------------------------------------------------------------------------------------------------------------------'" />
 
-				<!-- ************************ check needs ************************ -->
-				<do_if value="$alreadyServing or $priority.$serve == 'stationOrShip'">
-					<!-- CASE: station/ship -->
-					<!-- Note: by default the game treats buildstorage and the station as two seperate components. -->
-					<!-- Buyoffers from buildstorage will not show up at the station and vice versa -->
-					<set_value name="$currentlyServing" exact="if $alreadyServing then $alreadyServing.$stationOrShip else $homeStationOrShip"/>
-					<set_value name="$buyer" exact="if (($priority.$type == 'buildstorage') and ($currentlyServing.isclass.station)) then $currentlyServing.buildstorage else $currentlyServing"/>
-					<!-- buyoffer search -->
-					<find_buy_offer tradepartner="this.ship" wares="$allowedWares" buyer="$buyer" result="$needs" multiple="true"/>
-				</do_if>
-				<do_elseif value="$priority.$serve == 'sector'">
-					<!-- CASE: sector-->
-					<!-- $classes (buildstorage) -->
-					<set_value name="$serveClass" exact="if ($priority.$type == 'buildstorage') then class.buildstorage else [class.station, class.ship]"/>
-					<!-- buyoffer search -->
-					<find_buy_offer space="$homeSector" tradepartner="this.ship" wares="$allowedWares" result="$needs" multiple="true">
-						<match_buyer>
-							<match tradesknownto="this.owner"/>
-							<match class="$serveClass"/>
-							<match owner="$serveFactions"/>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-						</match_buyer>
-					</find_buy_offer>
-				</do_elseif>
-				<do_elseif value="$priority.$serve == 'area'">
-					<!-- CASE: area -->
-					<!-- $classes (buildstorage) -->
-					<set_value name="$serveClass" exact="if ($priority.$type == 'buildstorage') then class.buildstorage else [class.station, class.ship]"/>
-					<!-- buyoffer search -->
-					<find_buy_offer space="player.galaxy" tradepartner="this.ship" wares="$allowedWares" result="$needs" multiple="true">
-						<match_buyer>
-							<match class="$serveClass"/>
-							<match owner="$serveFactions"/>
-							<match_gate_distance object="$homeSector" min="0" max="$maxDist">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<!-- this next bit of mess is just blacklist handling -->
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-					</find_buy_offer>
-				</do_elseif>
+                <!-- ************************ check needs ************************ -->
+                <do_if value="$alreadyServing or $priority.$serve == 'stationOrShip'">
+                    <!-- CASE: station/ship -->
+                    <!-- Note: by default the game treats buildstorage and the station as two seperate components. -->
+                    <!-- Buyoffers from buildstorage will not show up at the station and vice versa -->
+                    <set_value name="$currentlyServing" exact="if $alreadyServing then $alreadyServing.$stationOrShip else $homeStationOrShip"/>
+                    <set_value name="$buyer" exact="if (($priority.$type == 'buildstorage') and ($currentlyServing.isclass.station)) then $currentlyServing.buildstorage else $currentlyServing"/>
+                    <!-- buyoffer search -->
+                    <find_buy_offer tradepartner="this.ship" wares="$allowedWares" buyer="$buyer" result="$needs" multiple="true"/>
+                </do_if>
+                <do_elseif value="$priority.$serve == 'sector'">
+                    <!-- CASE: sector-->
+                    <!-- $classes (buildstorage) -->
+                    <set_value name="$serveClass" exact="if ($priority.$type == 'buildstorage') then class.buildstorage else [class.station, class.ship]"/>
+                    <!-- buyoffer search -->
+                    <find_buy_offer space="$homeSector" tradepartner="this.ship" wares="$allowedWares" result="$needs" multiple="true">
+                        <match_buyer>
+                            <match tradesknownto="this.owner"/>
+                            <match class="$serveClass"/>
+                            <match owner="$serveFactions"/>
+                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                        </match_buyer>
+                    </find_buy_offer>
+                </do_elseif>
+                <do_elseif value="$priority.$serve == 'area'">
+                    <!-- CASE: area -->
+                    <!-- $classes (buildstorage) -->
+                    <set_value name="$serveClass" exact="if ($priority.$type == 'buildstorage') then class.buildstorage else [class.station, class.ship]"/>
+                    <!-- buyoffer search -->
+                    <find_buy_offer space="player.galaxy" tradepartner="this.ship" wares="$allowedWares" result="$needs" multiple="true">
+                        <match_buyer>
+                            <match class="$serveClass"/>
+                            <match owner="$serveFactions"/>
+                            <match_gate_distance object="$homeSector" min="0" max="$maxDist">
+                                <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                            </match_gate_distance>
+                            <!-- this next bit of mess is just blacklist handling -->
+                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                            <match_parent>
+                                <match_parent>
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                </match_parent>
+                            </match_parent>
+                        </match_buyer>
+                    </find_buy_offer>
+                </do_elseif>
 
-				<do_if value="$priority.$type != 'buildstorage'">
-					<!-- Filter needs(buyoffers) depending on resources, intermediates, tradewares -->
-					<!-- Create a tempoary list that should contain all needs based on the type given by the priority -->
-					<create_list name="$filteredNeeds" />
-					<!-- Check for every need if it fullfills the requirement and add -->
-					<do_for_each chance="100*($needs.count > 0)" name="$need" in="$needs">
-						<set_value name="$isResource" exact="$need.owner.resources.{$need.ware}.exists or $need.owner.supplyresources.{$need.ware}.exists"/>
-						<set_value name="$isProduct" exact="$need.owner.products.{$need.ware}.exists"/>
-						<!-- X4 treats products and resources always as tradewares... -->
-						<set_value name="$isWare" exact="$need.owner.tradewares.{$need.ware}.exists"/>
-						<do_if value="
-								 ($priority.$type == 'resources'     and $isResource and (not $isProduct)) or
-								 ($priority.$type == 'intermediates' and $isResource and $isProduct) or
-								 ($priority.$type == 'tradewares'    and $isWare and (not $isResource) and (not $isProduct))" >
-							<append_to_list name="$filteredNeeds" exact="$need" />
-						</do_if>
-					</do_for_each>
-					<set_value name="$needs" exact="$filteredNeeds"/>
-					<remove_value name="$filteredNeeds"/>
-				</do_if>
+                <do_if value="$priority.$type != 'buildstorage'">
+                    <!-- Filter needs(buyoffers) depending on resources, intermediates, tradewares -->
+                    <!-- Create a tempoary list that should contain all needs based on the type given by the priority -->
+                    <create_list name="$filteredNeeds" />
+                    <!-- Check for every need if it fullfills the requirement and add -->
+                    <do_for_each chance="100*($needs.count > 0)" name="$need" in="$needs">
+                        <set_value name="$isResource" exact="$need.owner.resources.{$need.ware}.exists or $need.owner.supplyresources.{$need.ware}.exists"/>
+                        <set_value name="$isProduct" exact="$need.owner.products.{$need.ware}.exists"/>
+                        <!-- X4 treats products and resources always as tradewares... -->
+                        <set_value name="$isWare" exact="$need.owner.tradewares.{$need.ware}.exists"/>
+                        <do_if value="
+                                 ($priority.$type == 'resources'     and $isResource and (not $isProduct)) or
+                                 ($priority.$type == 'intermediates' and $isResource and $isProduct) or
+                                 ($priority.$type == 'tradewares'    and $isWare and (not $isResource) and (not $isProduct))" >
+                            <append_to_list name="$filteredNeeds" exact="$need" />
+                        </do_if>
+                    </do_for_each>
+                    <set_value name="$needs" exact="$filteredNeeds"/>
+                    <remove_value name="$filteredNeeds"/>
+                </do_if>
 
-				<!-- dump all tradeoffers to debug log -->
-				<run_script chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
-					<param name="headerline" value="'needs'"/>
-					<param name="offers" value="$needs.clone"/>
-					<param name="debugchance" value="$debugchance"/>
-					<param name="debugFileName" value="$debugFileName"/>
-					<param name="debugDirName" value="$debugDirName"/>
-				</run_script>
+                <!-- dump all tradeoffers to debug log -->
+                <run_script chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
+                    <param name="headerline" value="'needs'"/>
+                    <param name="offers" value="$needs.clone"/>
+                    <param name="debugchance" value="$debugchance"/>
+                    <param name="debugFileName" value="$debugFileName"/>
+                    <param name="debugDirName" value="$debugDirName"/>
+                </run_script>
 
-				<!-- If there are no needs, just continue with the next on the priority list-->
-				<continue chance="100*($needs.count == 0)"/>
+                <!-- If there are no needs, just continue with the next on the priority list-->
+                <continue chance="100*($needs.count == 0)"/>
 
-				<!-- if we found some needs, set them to the specialWareBasket so they show up for the player in the UI -->
-				<!-- but only if the player didn't set them manually -->
-				<do_if value="(not $lockWares)">
-					<!-- To eliminate dublicates, just create a table with the ware as index -->
-					<set_value name="$uniqueWareTable" exact="table[]"/>
-					<do_for_each name="$need" in="$needs">
-						<set_value name="$uniqueWareTable.{$need.ware}" exact="$need.ware"/>
-					</do_for_each>
+                <!-- if we found some needs, set them to the specialWareBasket so they show up for the player in the UI -->
+                <!-- but only if the player didn't set them manually -->
+                <do_if value="(not $lockWares)">
+                    <!-- To eliminate dublicates, just create a table with the ware as index -->
+                    <set_value name="$uniqueWareTable" exact="table[]"/>
+                    <do_for_each name="$need" in="$needs">
+                        <set_value name="$uniqueWareTable.{$need.ware}" exact="$need.ware"/>
+                    </do_for_each>
 
-					<!-- now flush the old warebasket -->
-					<remove_from_list name="$specialWareBasket" />
-					<!-- and add all unique wares -->
-					<do_for_each name="$ware" in="$uniqueWareTable">
-						<append_to_list name="$specialWareBasket" exact="$ware" />
-					</do_for_each>
-				</do_if>
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'specialWareBasket: ' + $specialWareBasket" />
+                    <!-- now flush the old warebasket -->
+                    <remove_from_list name="$specialWareBasket" />
+                    <!-- and add all unique wares -->
+                    <do_for_each name="$ware" in="$uniqueWareTable">
+                        <append_to_list name="$specialWareBasket" exact="$ware" />
+                    </do_for_each>
+                </do_if>
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'specialWareBasket: ' + $specialWareBasket" />
 
-				<!-- ************************ search for suppliers ************************ -->
-				<find_sell_offer space="player.galaxy" tradepartner="this.ship" wares="$specialWareBasket" result="$supplyOffers" multiple="true">
-					<match_seller>
-						<match tradesknownto="this.owner"/>
-						<match owner="$priority.$supplierFactions"/>
-						<match_gate_distance object="$homeSector" min="0" max="$maxDist">
-							<blacklist group="blacklistgroup.civilian" object="this.ship" />
-						</match_gate_distance>
-						<!-- this next bit of mess is just blacklist handling -->
-						<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-						<match_parent>
-							<match_parent>
-								<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-								<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-							</match_parent>
-						</match_parent>
-					</match_seller>
-				</find_sell_offer>
+                <!-- ************************ search for suppliers ************************ -->
+                <find_sell_offer space="player.galaxy" tradepartner="this.ship" wares="$specialWareBasket" result="$supplyOffers" multiple="true">
+                    <match_seller>
+                        <match tradesknownto="this.owner"/>
+                        <match owner="$priority.$supplierFactions"/>
+                        <match_gate_distance object="$homeSector" min="0" max="$maxDist">
+                            <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                        </match_gate_distance>
+                        <!-- this next bit of mess is just blacklist handling -->
+                        <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                        <match_parent>
+                            <match_parent>
+                                <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                            </match_parent>
+                        </match_parent>
+                    </match_seller>
+                </find_sell_offer>
 
-				<!-- dump all tradeoffers to debug log -->
-				<run_script chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
-					<param name="headerline" value="'supply offers'"/>
-					<param name="offers" value="$supplyOffers.clone"/>
-					<param name="debugchance" value="$debugchance"/>
-					<param name="debugFileName" value="$debugFileName"/>
-					<param name="debugDirName" value="$debugDirName"/>
-				</run_script>
+                <!-- dump all tradeoffers to debug log -->
+                <run_script chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
+                    <param name="headerline" value="'supply offers'"/>
+                    <param name="offers" value="$supplyOffers.clone"/>
+                    <param name="debugchance" value="$debugchance"/>
+                    <param name="debugFileName" value="$debugFileName"/>
+                    <param name="debugDirName" value="$debugDirName"/>
+                </run_script>
 
-				<!-- ************************ evalute offers & issue orders ************************ -->
-				<!-- If we have found matching supply start profit calculation and issue orders -->
-				<do_if value="$supplyOffers.count">
-					<!-- some setup, repeats in every block for readability -->
-					<set_value name="$ShipCapacity" exact="this.ship.cargo.capacity.all" />
-					<!-- by hacking the maxTrades to 1 we make the supply mule have some trouble finding trades, so we need to add some leniency 
-					until we can figure out a longer term solution.... which may be a cargo % slider? -->
-					<set_value name="$minCargoSize" exact="($minCargoUsed/100.0)*($ShipCapacity)f / $maxTrades" />
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ship capacity: ' + $ShipCapacity" />
+                <!-- ************************ evalute offers & issue orders ************************ -->
+                <!-- If we have found matching supply start profit calculation and issue orders -->
+                <do_if value="$supplyOffers.count">
+                    <!-- some setup, repeats in every block for readability -->
+                    <set_value name="$ShipCapacity" exact="this.ship.cargo.capacity.all" />
+                    <!-- by hacking the maxTrades to 1 we make the supply mule have some trouble finding trades, so we need to add some leniency 
+                    until we can figure out a longer term solution.... which may be a cargo % slider? -->
+                    <set_value name="$minCargoSize" exact="($minCargoUsed/100.0)*($ShipCapacity)f / $maxTrades" />
+                    <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'ship capacity: ' + $ShipCapacity" />
 
-					<!-- these lists will hold the trades we want to make. we'll check they're still available before creating the orders -->
-					<create_list name="$supplyTrades" />
-					<!-- looping over the max number of trade in the UI. if cargo is full already we'll break -->
-					<set_value name="$occupiedCargo" exact="$ShipCapacity - this.ship.cargo.free.all" />
-					<set_value name="$emergencyBreak" exact="0"/>
-					<do_while value="true">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Occupied Cargo: ' + $occupiedCargo" />
+                    <!-- these lists will hold the trades we want to make. we'll check they're still available before creating the orders -->
+                    <create_list name="$supplyTrades" />
+                    <!-- looping over the max number of trade in the UI. if cargo is full already we'll break -->
+                    <set_value name="$occupiedCargo" exact="$ShipCapacity - this.ship.cargo.free.all" />
+                    <set_value name="$emergencyBreak" exact="0"/>
+                    <do_while value="true">
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Occupied Cargo: ' + $occupiedCargo" />
 
-						<!-- emergency break to prevent mule from freezing the screen (in theory they should never crash) -->
-						<set_value name="$emergencyBreak" operation="add" exact="1"/>
-						<do_if value="$emergencyBreak > 100">
-							<set_value name="$emergencyText" exact="'Suppymule %s (%s) crashed. Check debug log for more infos and report this error to the mod developers (with a full debug log file).'.[this.ship.knownname, this.ship.idcode]"/>
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$emergencyText" />
-							<write_to_logbook category="alerts" object="this.ship" title="'Supplymule crashed!'" interaction="showonmap" text="$emergencyText" />
-							<create_order object="this.ship" id="Wait" default="true"/>
-							<return/>
-						</do_if>
+                        <!-- emergency break to prevent mule from freezing the screen (in theory they should never crash) -->
+                        <set_value name="$emergencyBreak" operation="add" exact="1"/>
+                        <do_if value="$emergencyBreak > 100">
+                            <set_value name="$emergencyText" exact="'Suppymule %s (%s) crashed. Check debug log for more infos and report this error to the mod developers (with a full debug log file).'.[this.ship.knownname, this.ship.idcode]"/>
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$emergencyText" />
+                            <write_to_logbook category="alerts" object="this.ship" title="'Supplymule crashed!'" interaction="showonmap" text="$emergencyText" />
+                            <create_order object="this.ship" id="Wait" default="true"/>
+                            <return/>
+                        </do_if>
 
-						<do_if value="$occupiedCargo + $minCargoSize / 2.0 ge $ShipCapacity">
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Cargo Full, skip to end'" />
-							<!-- cargo full, skip to end -->
-							<resume label="end"/>
-						</do_if>
-						<do_if value="$tradeCount == $maxTrades">
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'max trades, skip to end'" />
-							<!-- max trades, skip to end -->
-							<resume label="end"/>
-						</do_if>
+                        <do_if value="$occupiedCargo + $minCargoSize / 2.0 ge $ShipCapacity">
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Cargo Full, skip to end'" />
+                            <!-- cargo full, skip to end -->
+                            <resume label="end"/>
+                        </do_if>
+                        <do_if value="$tradeCount == $maxTrades">
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'max trades, skip to end'" />
+                            <!-- max trades, skip to end -->
+                            <resume label="end"/>
+                        </do_if>
 
-						<!-- Compare tradeoffers by profit and return the most profitable one -->
-						<!-- We might want to offer to fill critical resources with highest priority -->
-						<run_script name="'mule.lib.evaluate_tradeoffers'">
-							<!-- use clone for a shallow copy of objects (pass by reference) -->
-							<param name="buyoffers" value="$needs.clone"/>
-							<param name="selloffers" value="$supplyOffers.clone"/>
-							<param name="shipEntity" value="this"/>
-							<param name="occupiedCargo" value="$occupiedCargo"/>
-							<param name="minCargoSize" value="$minCargoSize"/>
-							<param name="sameFactionBuyMod" value="$playerBuyMod"/>
-							<param name="debugchance" value="$debugchance"/>
-							<param name="debugFileName" value="$debugFileName"/>
-							<param name="debugDirName" value="$debugDirName"/>
-							<param name="dedicatedPlayerBuilder" value="$isDedicatedPlayerBuilder" />
-							<save_retval name="bestProfit" variable="$bestProfit"/>
-							<save_retval name="bestAmount" variable="$bestAmount"/>
-							<save_retval name="bestNeedTrade" variable="$bestNeedTrade"/>
-							<save_retval name="bestSupplyTrade" variable="$bestSupplyTrade"/>
-						</run_script>
+                        <!-- Compare tradeoffers by profit and return the most profitable one -->
+                        <!-- We might want to offer to fill critical resources with highest priority -->
+                        <run_script name="'mule.lib.evaluate_tradeoffers'">
+                            <!-- use clone for a shallow copy of objects (pass by reference) -->
+                            <param name="buyoffers" value="$needs.clone"/>
+                            <param name="selloffers" value="$supplyOffers.clone"/>
+                            <param name="shipEntity" value="this"/>
+                            <param name="occupiedCargo" value="$occupiedCargo"/>
+                            <param name="minCargoSize" value="$minCargoSize"/>
+                            <param name="sameFactionBuyMod" value="$playerBuyMod"/>
+                            <param name="debugchance" value="$debugchance"/>
+                            <param name="debugFileName" value="$debugFileName"/>
+                            <param name="debugDirName" value="$debugDirName"/>
+                            <param name="dedicatedPlayerBuilder" value="$isDedicatedPlayerBuilder" />
+                            <save_retval name="bestProfit" variable="$bestProfit"/>
+                            <save_retval name="bestAmount" variable="$bestAmount"/>
+                            <save_retval name="bestNeedTrade" variable="$bestNeedTrade"/>
+                            <save_retval name="bestSupplyTrade" variable="$bestSupplyTrade"/>
+                        </run_script>
 
-						<!-- if we found a good trade, create the buy order for the supply and the sell order for the need. -->
-						<!-- if we end up with more than one need, we'll move it down with move_order later -->
-						<do_if value="$bestProfit le 0">
-							<!-- No more profitable trades, move on to next priority! -->
-							<break/>
-						</do_if>
+                        <!-- if we found a good trade, create the buy order for the supply and the sell order for the need. -->
+                        <!-- if we end up with more than one need, we'll move it down with move_order later -->
+                        <do_if value="$bestProfit le 0">
+                            <!-- No more profitable trades, move on to next priority! -->
+                            <break/>
+                        </do_if>
 
-						<do_if value="$bestSupplyTrade.available and $bestNeedTrade.available">
-							<set_value name="$tradeText" exact="'buying %s %s from %s (%s) at %s  to sell to %s (%s) at %s for a profit of %s.'.[$bestAmount, $bestNeedTrade.ware, $bestSupplyTrade.owner.knownname, $bestSupplyTrade.owner.idcode, $bestSupplyTrade.unitprice.formatted.{'%s %Cr'}, $bestNeedTrade.owner.knownname, $bestNeedTrade.owner.idcode, $bestNeedTrade.unitprice.formatted.{'%s %Cr'}, $bestProfit.formatted.{'%s %Cr'}]"/>
-							<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$tradeText" />
-							<write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="$tradeText" />
+                        <do_if value="$bestSupplyTrade.available and $bestNeedTrade.available">
+                            <set_value name="$tradeText" exact="'buying %s %s from %s (%s) at %s  to sell to %s (%s) at %s for a profit of %s.'.[$bestAmount, $bestNeedTrade.ware, $bestSupplyTrade.owner.knownname, $bestSupplyTrade.owner.idcode, $bestSupplyTrade.unitprice.formatted.{'%s %Cr'}, $bestNeedTrade.owner.knownname, $bestNeedTrade.owner.idcode, $bestNeedTrade.unitprice.formatted.{'%s %Cr'}, $bestProfit.formatted.{'%s %Cr'}]"/>
+                            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="$tradeText" />
+                            <write_to_logbook category="upkeep"  object="this.ship" title="$logbookEntryTitle" interaction="showonmap" money="$bestProfit" text="$tradeText" />
 
-							<create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
-							<create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
+                            <create_trade_order name="$bestOrder" object="this.ship" tradeoffer="$bestSupplyTrade" amount="$bestAmount"  immediate="true"/>
+                            <create_trade_order object="this.ship" tradeoffer="$bestNeedTrade" amount="$bestAmount" />
 
-							<!-- might be able remove $occupiedCargo in the future -->
-							<set_value name="$occupiedCargo" exact="$occupiedCargo + $bestAmount * $bestSupplyTrade.ware.volume" />
-							<!-- Lock in out trading station -->
-							<do_if value="$alreadyServing == null">
-								<!-- prevent the mule from using any other trade stations on this run/priority, by removing all other buyoffers/needs from different stations -->
-								<create_list name="$filteredNeeds" />
-								<do_for_each name="$need" in="$needs">
-									<append_to_list chance="100*($need.buyer == $bestNeedTrade.buyer)" name="$filteredNeeds" exact="$need" />
-								</do_for_each>
-								<set_value name="$needs" exact="$filteredNeeds"/>
-								<remove_value name="$filteredNeeds"/>
-								<!-- prevent searching for buyoffers from other stations in the next run/priority -->
-								<set_value name="$alreadyServing" exact="table[$serve = $priority.$serve ,$stationOrShip = $bestNeedTrade.buyer]"/>
-							</do_if>
-							<!-- remove used supply offers from evaluation -->
-							<remove_from_list name="$supplyOffers" exact="$bestSupplyTrade"/>
-							<!-- Trade Count -->
-							<set_value name="$tradeCount" operation="add" exact="1"/>
-						</do_if>
-					</do_while>
-				</do_if>
-			</do_for_each>
+                            <!-- might be able remove $occupiedCargo in the future -->
+                            <set_value name="$occupiedCargo" exact="$occupiedCargo + $bestAmount * $bestSupplyTrade.ware.volume" />
+                            <!-- Lock in out trading station -->
+                            <do_if value="$alreadyServing == null">
+                                <!-- prevent the mule from using any other trade stations on this run/priority, by removing all other buyoffers/needs from different stations -->
+                                <create_list name="$filteredNeeds" />
+                                <do_for_each name="$need" in="$needs">
+                                    <append_to_list chance="100*($need.buyer == $bestNeedTrade.buyer)" name="$filteredNeeds" exact="$need" />
+                                </do_for_each>
+                                <set_value name="$needs" exact="$filteredNeeds"/>
+                                <remove_value name="$filteredNeeds"/>
+                                <!-- prevent searching for buyoffers from other stations in the next run/priority -->
+                                <set_value name="$alreadyServing" exact="table[$serve = $priority.$serve ,$stationOrShip = $bestNeedTrade.buyer]"/>
+                            </do_if>
+                            <!-- remove used supply offers from evaluation -->
+                            <remove_from_list name="$supplyOffers" exact="$bestSupplyTrade"/>
+                            <!-- Trade Count -->
+                            <set_value name="$tradeCount" operation="add" exact="1"/>
+                        </do_if>
+                    </do_while>
+                </do_if>
+            </do_for_each>
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Nothing found, check back in a couple of minuites....'" />
-			<wait min="3min" max="5min" />
-			<resume label="start"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Nothing found, check back in a couple of minuites....'" />
+            <wait min="3min" max="5min" />
+            <resume label="start"/>
 
-			<label name="end" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'******* went to end'" />
-			<return/>
-			<!-- Absolutly ridicules workaround to surpress any messages related to blocking actions -->
-			<!-- Basicially, we add a bunch of blocking actions that are never reached. -->
-			<!-- This ensures, that our block action index in the savegames never exceeds the actual number of blocking actions. -->
-			<!-- Therefore, if we were to delete a blocking action above, the savegame will load without throwing an error message -->
-			<!-- Note, that the script state in this case is totally wrong, since the game will load the variables from the last game. -->
-			<!-- This is mitiagted, by restarting the order with a´patch command on load. -->
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-		</actions>
-	</attention>
+            <label name="end" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'******* went to end'" />
+            <return/>
+            <!-- Absolutly ridicules workaround to surpress any messages related to blocking actions -->
+            <!-- Basicially, we add a bunch of blocking actions that are never reached. -->
+            <!-- This ensures, that our block action index in the savegames never exceeds the actual number of blocking actions. -->
+            <!-- Therefore, if we were to delete a blocking action above, the savegame will load without throwing an error message -->
+            <!-- Note, that the script state in this case is totally wrong, since the game will load the variables from the last game. -->
+            <!-- This is mitiagted, by restarting the order with a´patch command on load. -->
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+        </actions>
+    </attention>
 </aiscript>

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<aiscript name="supplymule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="4">
+<aiscript name="supplymule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="5">
 	<!-- Setup context menu order-->
 	<order id="SupplyMule" name="{61552,4001}" description="{61552,4101}" category="trade" infinite="true">
 		<params>
@@ -122,7 +122,7 @@
 		</do_if>
 	</init>
 
-	<patch sinceversion="2">
+	<patch sinceversion="5">
 		<!-- This will reissue any standing supply mule orders -->
 		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
 		<debug_text text="'PATCH: Restarting supply mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
@@ -219,73 +219,18 @@
 				<wait min="50ms" max="150ms" />
 			</do_for_each>
 
-			<!-- Sell leftover cargo before resuming regular Mule routine -->
-			<!-- this was pulled right out of the randomTrader mod -->
-			<set_value name="$profitScale" exact="50" />
-			<set_value name="$pilotSkill" exact="this.ship.pilot.skill.piloting" />
-			<set_value name="$maxBuyRelPrice" exact="((-0.325-0.025*($pilotSkill)f)/90.0-0.01)*($profitScale)f+1-(-0.325-0.025*($pilotSkill)f)/9.0" />
-			<set_value name="$searchStep" exact="(1.0-$maxBuyRelPrice)/4.0" />
-
+			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
 			<set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_all exact="$cargo.count" counter="$wareInCargo">
-				<wait min="50ms" max="150ms" />
-
-				<set_value name="$moneyToHack" exact="1000000000" />
-				<reward_player money="$moneyToHack" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'player reward '+$moneyToHack" />
-
-
-				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
-				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
-
-				<do_all exact="5" counter="$reduction">
-					<!--searching suiting buy offer, will search 5 times reducing requirements each time by 20% (just want to get rid of that stuff at some point)-->
-					<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$buyOffer" wares="$currentWare">
-						<match_buyer tradesknownto="this.owner">
-							<match_gate_distance object="this.ship" min="0" max="8">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-						<relativeprice min="-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001" />
-						<amount min="$amount*(0.8^($reduction-1))" />
-					</find_buy_offer>
-					<wait min="50ms" max="150ms" />
-
-					<do_if value="$buyOffer == null">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates : 8'" />
-						<continue />
-					</do_if>
-
-					<set_value name="$amount" exact="[$amount,$buyOffer.amount].min" />
-
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
-
-					<do_if value="$buyOffer.available">
-						<write_to_logbook category="general" title="$logbookEntryTitle" interaction="showonmap" object="this.ship" money="$buyOffer.unitprice*$amount" text="'Selling '+$amount+' '+$currentWare+', unitprice: '+$buyOffer.unitprice/100.0" />
-						<create_trade_order object="this.ship" amount="$amount" tradeoffer="$buyOffer" />
-						<debug_to_file name="$debugFileName" directory="$debugDirName" text="'  trade created'" />
-						<resume label="end" />
-					</do_if>
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  offer not available anymore'" />
-				</do_all>
-				<!-- if we got to this point without finding a buyer, we're just going to dump the ware -->
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  had to drop %1 of %2'.[$amount,$currentWare]" />
-				<write_to_logbook category="general" title="$logbookEntryTitle" interaction="showonmap" object="this.ship" text="'had to drop %1 of %2 due to no buyers'.[$amount,$currentWare]" />
-				<drop_cargo object="this.ship" ware="$currentWare" exact="$amount" />
-			</do_all>
-
-			<remove_value name="$searchStep" />
-			<remove_value name="$cargo" />
-			<remove_value name="$buyOffer" />
+			<do_if value="$cargo.count gt 0">
+				<run_script name="'mule.lib.empty_cargo'">
+					<param name="debugchance" value="$debugchance" />
+					<param name="debugFileName" value="$debugFileName" />
+					<param name="debugDirName" value="$debugDirName" />
+					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
+					<param name="cargo" value="$cargo" />
+				</run_script>
+			</do_if>
 
 			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  cargo is full =('" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -231,6 +231,11 @@
 			<do_all exact="$cargo.count" counter="$wareInCargo">
 				<wait min="50ms" max="150ms" />
 
+				<set_value name="$moneyToHack" exact="1000000000" />
+				<reward_player money="$moneyToHack" />
+				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'player reward '+$moneyToHack" />
+
+
 				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
 				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />

--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -1,485 +1,485 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <aiscript name="travelmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="4">
-	<!-- Setup context menu order -->
-	<order id="TravelMule" name="{61552,1001}" description="{61552,1101}" category="trade" infinite="true">
-		<params>
-			<!-- menu option: Source Station (Define Source Station) -->
-			<param name="sourceStation" required="false" default="null" type="object" text="{61552,1002}" comment="{61552,1102}">
-				<input_param name="class" value="[class.station]" />
-			</param>
-			<!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
-			<param name="assignSrc" type="bool" default="true" text="{61552,2004}" comment="{61552,2104}">
-				<patch sinceversion="3" value="true"/>
-			</param>
-			<!-- menu option: Max Gate Distance -->
-			<param name="maxDist" required="false" default="8" type="number" text="{61552,1003}" comment="{61552,1103}">
-				<input_param name="startvalue" value="15" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="15" />
-				<input_param name="step" value="1" />
-			</param>
-			<!-- menu option: Profit Override Percentage (Used when buying/selling at own warehouses mostly) -->
-			<param name="profitMargin" default="90" type="number" text="{61552,1004}" comment="{61552,1104}">
-				<input_param name="startvalue" value="90" />
-				<input_param name="min" value="0" />
-				<input_param name="max" value="100" />
-				<input_param name="step" value="5" />
-			</param>
-			<!-- lock wares to player selection -->
-			<param name="lockWares" type="bool" default="false" text="{61552,1005}" comment="{61552,1105}" />
-			<!-- menu option: WareBasket List -->
-			<param name="specialWareBasket" required="false" default="[]" type="list" text="{61552,1006}" comment="{61552,1106}">
-				<input_param name="type" value="'ware'" />
-				<input_param name="cancarry" value="this.ship" />
-			</param>
-			<!-- menu option: Cargo Percentage Used for Trade -->
-			<param name="minCargoUsed" default="80" type="number" text="{61552,1007}" comment="{61552,1107}">
-				<input_param name="startvalue" value="80" />
-				<input_param name="min" value="25" />
-				<input_param name="max" value="95" />
-				<input_param name="step" value="5" />
-			</param>
+    <!-- Setup context menu order -->
+    <order id="TravelMule" name="{61552,1001}" description="{61552,1101}" category="trade" infinite="true">
+        <params>
+            <!-- menu option: Source Station (Define Source Station) -->
+            <param name="sourceStation" required="false" default="null" type="object" text="{61552,1002}" comment="{61552,1102}">
+                <input_param name="class" value="[class.station]" />
+            </param>
+            <!-- menu option: Assign Ship to Station (Are we assigning this ship to a station if player owned.) -->
+            <param name="assignSrc" type="bool" default="true" text="{61552,2004}" comment="{61552,2104}">
+                <patch sinceversion="3" value="true"/>
+            </param>
+            <!-- menu option: Max Gate Distance -->
+            <param name="maxDist" required="false" default="8" type="number" text="{61552,1003}" comment="{61552,1103}">
+                <input_param name="startvalue" value="15" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="15" />
+                <input_param name="step" value="1" />
+            </param>
+            <!-- menu option: Profit Override Percentage (Used when buying/selling at own warehouses mostly) -->
+            <param name="profitMargin" default="90" type="number" text="{61552,1004}" comment="{61552,1104}">
+                <input_param name="startvalue" value="90" />
+                <input_param name="min" value="0" />
+                <input_param name="max" value="100" />
+                <input_param name="step" value="5" />
+            </param>
+            <!-- lock wares to player selection -->
+            <param name="lockWares" type="bool" default="false" text="{61552,1005}" comment="{61552,1105}" />
+            <!-- menu option: WareBasket List -->
+            <param name="specialWareBasket" required="false" default="[]" type="list" text="{61552,1006}" comment="{61552,1106}">
+                <input_param name="type" value="'ware'" />
+                <input_param name="cancarry" value="this.ship" />
+            </param>
+            <!-- menu option: Cargo Percentage Used for Trade -->
+            <param name="minCargoUsed" default="80" type="number" text="{61552,1007}" comment="{61552,1107}">
+                <input_param name="startvalue" value="80" />
+                <input_param name="min" value="25" />
+                <input_param name="max" value="95" />
+                <input_param name="step" value="5" />
+            </param>
 
-			<!-- menu option: Target NPC Shipyards, Whalfs, Equipment Docks -->
-			<param name="tradeWithBig" required="false" type="bool" default="false" text="{61552,1008}" comment="{61552,1108}" />
-			<!-- menu option: Target All NPC Stations (trade with any station toggle) -->
-			<param name="tradeWithAll" required="false" type="bool" default="true" text="{61552,1009}" comment="{61552,1109}" />
+            <!-- menu option: Target NPC Shipyards, Whalfs, Equipment Docks -->
+            <param name="tradeWithBig" required="false" type="bool" default="false" text="{61552,1008}" comment="{61552,1108}" />
+            <!-- menu option: Target All NPC Stations (trade with any station toggle) -->
+            <param name="tradeWithAll" required="false" type="bool" default="true" text="{61552,1009}" comment="{61552,1109}" />
 
-			<!-- menu option: Destination Override (select stations manually to visit) -->
-			<param name="destList" required="false" default="[]" type="list" text="{61552,1010}" comment="{61552,1110}">
-				<input_param name="type" value="'object'" />
-			</param>
-			<param name="restartScript" type="internal" default="false"/>
+            <!-- menu option: Destination Override (select stations manually to visit) -->
+            <param name="destList" required="false" default="[]" type="list" text="{61552,1010}" comment="{61552,1110}">
+                <input_param name="type" value="'object'" />
+            </param>
+            <param name="restartScript" type="internal" default="false"/>
 
-		</params>
-		<requires>
-			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
-			<!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
-			<match shiptype="shiptype.lasertower" negate="true" />
-		</requires>
-	</order>
+        </params>
+        <requires>
+            <!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
+            <!-- This denies laser towers from being able to get this order (more precisely in our case, this default behaviour) -->
+            <match shiptype="shiptype.lasertower" negate="true" />
+        </requires>
+    </order>
 
-	<interrupts>
-		<handler ref="AttackHandler" />
-		<handler ref="MissileLockHandler" />
-		<handler ref="ScannedHandler" />
-		<handler ref="InspectedHandler" />
-		<handler ref="FoundAbandonedHandler" />
-		<handler ref="ResupplyHandler" />
-		<handler ref="JobRemoveRequestHandler" />
-		<handler ref="TargetInvalidHandler" />
-	</interrupts>
+    <interrupts>
+        <handler ref="AttackHandler" />
+        <handler ref="MissileLockHandler" />
+        <handler ref="ScannedHandler" />
+        <handler ref="InspectedHandler" />
+        <handler ref="FoundAbandonedHandler" />
+        <handler ref="ResupplyHandler" />
+        <handler ref="JobRemoveRequestHandler" />
+        <handler ref="TargetInvalidHandler" />
+    </interrupts>
 
-	<init>
-		<set_value name="$debugchance" exact="100" />
-		<set_value name="$object" exact="this.assignedcontrolled" />
-		<set_order_syncpoint_reached order="this.ship.order" />
-		<set_command_action commandaction="commandaction.searchingtrades" />
-		<!-- Exception for civilian fleets -->
-		<do_if value="($sourceStation.owner == this.ship.owner) and (not (@this.ship.commander.isclass.ship and this.ship.assignment != assignment.trade)) and ($assignSrc)">
-			<set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
-		</do_if>
-		<set_value name="$debugFileName" exact="'travelmule - ' + this.ship.idcode" />
-		<set_value name="$debugDirName" exact="'MulesExtended'"/>
-		<set_value name="$logbookEntryTitle" exact="'TravelMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
-	</init>
-	
-	<patch sinceversion="4">
-		<!-- This will reissue any standing travel mule orders -->
-		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
-		<debug_text text="'PATCH: Restarting travel mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
-		<edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
-	</patch>
+    <init>
+        <set_value name="$debugchance" exact="100" />
+        <set_value name="$object" exact="this.assignedcontrolled" />
+        <set_order_syncpoint_reached order="this.ship.order" />
+        <set_command_action commandaction="commandaction.searchingtrades" />
+        <!-- Exception for civilian fleets -->
+        <do_if value="($sourceStation.owner == this.ship.owner) and (not (@this.ship.commander.isclass.ship and this.ship.assignment != assignment.trade)) and ($assignSrc)">
+            <set_object_commander object="this.ship" commander="$sourceStation" assignment="assignment.trade" />
+        </do_if>
+        <set_value name="$debugFileName" exact="'travelmule - ' + this.ship.idcode" />
+        <set_value name="$debugDirName" exact="'MulesExtended'"/>
+        <set_value name="$logbookEntryTitle" exact="'TravelMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
+    </init>
+    
+    <patch sinceversion="4">
+        <!-- This will reissue any standing travel mule orders -->
+        <!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
+        <debug_text text="'PATCH: Restarting travel mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
+        <edit_order_param order="this.assignedcontrolled.order" param="'restartScript'" value="true"/>
+    </patch>
 
-	<attention min="unknown">
-		<actions>
-			<label name="start" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Starting Log File'" output="false" append="false" />
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Entity (this): %s'.[this]"/>
+    <attention min="unknown">
+        <actions>
+            <label name="start" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Starting Log File'" output="false" append="false" />
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Ship: %s (%s) - %s'.[this.ship.knownname, this.ship.idcode, this.ship]"/>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Entity (this): %s'.[this]"/>
 
-			<create_list name="$supplies" />
-			<create_list name="$needs" />
-			<create_list name="$innerList" />
-			<create_list name="$outerList" />
-			<create_list name="$tempList" />
+            <create_list name="$supplies" />
+            <create_list name="$needs" />
+            <create_list name="$innerList" />
+            <create_list name="$outerList" />
+            <create_list name="$tempList" />
 
-			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
-			<set_value name="$cargo" exact="this.ship.cargo.list" />
+            <!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
+            <set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_if value="$cargo.count gt 0">
-				<run_script name="'mule.lib.empty_cargo'">
-					<param name="debugchance" value="$debugchance" />
-					<param name="debugFileName" value="$debugFileName" />
-					<param name="debugDirName" value="$debugDirName" />
-					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
-					<param name="cargo" value="$cargo" />
-				</run_script>
-			</do_if>
+            <do_if value="$cargo.count gt 0">
+                <run_script name="'mule.lib.empty_cargo'">
+                    <param name="debugchance" value="$debugchance" />
+                    <param name="debugFileName" value="$debugFileName" />
+                    <param name="debugDirName" value="$debugDirName" />
+                    <param name="logbookEntryTitle" value="$logbookEntryTitle" />
+                    <param name="cargo" value="$cargo" />
+                </run_script>
+            </do_if>
 
-			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'TravelMule'" text="'  cargo is full =('" />
-				<wait min="50ms" max="150ms" />
-				<resume label="start" />
-			</do_if>
+            <do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="'TravelMule'" text="'  cargo is full =('" />
+                <wait min="50ms" max="150ms" />
+                <resume label="start" />
+            </do_if>
 
-			<!-- the previous mules method stops the issue where user input wares are overwritten, but the side effect is that the user
-			can't see the warebasket selected by the mule, which I think is very important for the user to understand what
-			the mule is doing. My solution is to add a checkbox to lock the user wares, then populate the UI variable
-			with the wareBasket the mule finds from searching for offers -->
-			<do_if value="(not $lockWares)">
-				<set_value name="$wareBasket" exact="[]" />
-				<do_if value="$sourceStation.tradewares.count">
-					<append_list_elements name="$wareBasket" other="$sourceStation.tradewares.list" />
-				</do_if>
-				<do_if value="$sourceStation.products.count">
-					<append_list_elements name="$wareBasket" other="$sourceStation.products.list" />
-				</do_if>
-				<do_if value="$wareBasket.count">
-					<remove_from_list name="$specialWareBasket" />
-					<append_list_elements name="$specialWareBasket" other="$wareBasket" />
-				</do_if>
-			</do_if>
-			<do_else>
-				<set_value name="$wareBasket" exact="$specialWareBasket" />
-			</do_else>
+            <!-- the previous mules method stops the issue where user input wares are overwritten, but the side effect is that the user
+            can't see the warebasket selected by the mule, which I think is very important for the user to understand what
+            the mule is doing. My solution is to add a checkbox to lock the user wares, then populate the UI variable
+            with the wareBasket the mule finds from searching for offers -->
+            <do_if value="(not $lockWares)">
+                <set_value name="$wareBasket" exact="[]" />
+                <do_if value="$sourceStation.tradewares.count">
+                    <append_list_elements name="$wareBasket" other="$sourceStation.tradewares.list" />
+                </do_if>
+                <do_if value="$sourceStation.products.count">
+                    <append_list_elements name="$wareBasket" other="$sourceStation.products.list" />
+                </do_if>
+                <do_if value="$wareBasket.count">
+                    <remove_from_list name="$specialWareBasket" />
+                    <append_list_elements name="$specialWareBasket" other="$wareBasket" />
+                </do_if>
+            </do_if>
+            <do_else>
+                <set_value name="$wareBasket" exact="$specialWareBasket" />
+            </do_else>
 
-			<!-- technically sourceStation could be owned by someone on the blacklist, but the player picked this manually -->
-			<find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" wares="$wareBasket" multiple="true">
-				<match_seller>
-					<match_gate_distance object="this.ship" min="0">
-						<blacklist group="blacklistgroup.civilian" object="this.ship" />
-					</match_gate_distance>
-					<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-					<match_parent>
-						<match_parent>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-						</match_parent>
-					</match_parent>
-				</match_seller>
-			</find_sell_offer>
+            <!-- technically sourceStation could be owned by someone on the blacklist, but the player picked this manually -->
+            <find_sell_offer tradepartner="this.ship" seller="$sourceStation" result="$supplies" wares="$wareBasket" multiple="true">
+                <match_seller>
+                    <match_gate_distance object="this.ship" min="0">
+                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                    </match_gate_distance>
+                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                    <match_parent>
+                        <match_parent>
+                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                        </match_parent>
+                    </match_parent>
+                </match_seller>
+            </find_sell_offer>
 
-			<run_script sinceversion="2" chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
-				<param name="headerline" value="'supplies'"/>
-				<param name="offers" value="$supplies.clone"/>
-				<param name="debugchance" value="$debugchance"/>
-				<param name="debugFileName" value="$debugFileName"/>
-				<param name="debugDirName" value="$debugDirName"/>
-			</run_script>
+            <run_script sinceversion="2" chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
+                <param name="headerline" value="'supplies'"/>
+                <param name="offers" value="$supplies.clone"/>
+                <param name="debugchance" value="$debugchance"/>
+                <param name="debugFileName" value="$debugFileName"/>
+                <param name="debugDirName" value="$debugDirName"/>
+            </run_script>
 
-			<!-- TODO: refactor these blocks -->
-			<!-- maxDist of 15 is the equivalent of "no limit" apparently -->
-			<!-- Finding Buyers -->
-			<do_if value="$destList == []">
-				<do_if value="$maxDist == 15">
-					<do_if value="$tradeWithAll">
-						<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$needs" wares="$wareBasket" multiple="true">
-							<match_buyer>
-								<match_gate_distance object="$sourceStation" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-								<match_relation_to object="this.ship" relation="enemy" comparison="not" />
-								<match tradesknownto="this.owner" />
-								<match owner="this.ship.owner" negate="true" />
-								<match class="class.station" />
-								<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-								<match_parent>
-									<match_parent>
-										<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-										<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-									</match_parent>
-								</match_parent>
-							</match_buyer>
-						</find_buy_offer>
-					</do_if>
-					<do_elseif value="$tradeWithBig">
-						<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$needs" wares="$wareBasket" multiple="true">
-							<match_buyer>
-								<match_gate_distance object="$sourceStation" min="0">
-									<blacklist group="blacklistgroup.civilian" object="this.ship" />
-								</match_gate_distance>
-								<match_relation_to object="this.ship" relation="enemy" comparison="not" />
-								<match tradesknownto="this.owner" />
-								<match owner="this.ship.owner" negate="true" />
-								<match class="class.station" />
-								<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-								<match_parent>
-									<match_parent>
-										<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-										<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-									</match_parent>
-								</match_parent>
-								<match_any>
-									<match canbuildships="true" />
-									<match canequipships="true" />
-								</match_any>
-							</match_buyer>
-						</find_buy_offer>
-					</do_elseif>
-				</do_if>
-				<do_else>
-					<find_cluster_in_range distances="$clusterstable" multiple="true" object="$sourceStation.cluster" mindistance="0" maxdistance="$maxDist" />
-					<set_value name="$sellspaces" exact="$clusterstable.keys.sorted" />
-					<remove_value name="$clusterstable" />
-					<do_all exact="$sellspaces.count" counter="$sector">
-						<do_if value="$tradeWithAll">
-							<find_buy_offer tradepartner="this.ship" space="$sellspaces.{$sector}" result="$tempList" wares="$wareBasket" multiple="true">
-								<match_buyer>
-									<match_gate_distance object="$sourceStation" max="$maxDist">
-										<blacklist group="blacklistgroup.civilian" object="this.ship" />
-									</match_gate_distance>
-									<match_relation_to object="this.ship" relation="enemy" comparison="not" />
-									<match tradesknownto="this.owner" />
-									<match owner="this.ship.owner" negate="true" />
-									<match class="class.station" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-									<match_parent>
-										<match_parent>
-											<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-											<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-										</match_parent>
-									</match_parent>
-								</match_buyer>
-							</find_buy_offer>
-						</do_if>
-						<do_elseif value="$tradeWithBig">
-							<find_buy_offer tradepartner="this.ship" space="$sellspaces.{$sector}" result="$tempList" wares="$wareBasket" multiple="true">
-								<match_buyer>
-									<match_gate_distance object="$sourceStation" max="$maxDist">
-										<blacklist group="blacklistgroup.civilian" object="this.ship" />
-									</match_gate_distance>
-									<match_relation_to object="this.ship" relation="enemy" comparison="not" />
-									<match tradesknownto="this.owner" />
-									<match owner="this.ship.owner" negate="true" />
-									<match class="class.station" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-									<match_parent>
-										<match_parent>
-											<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-											<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-										</match_parent>
-									</match_parent>
-									<match_any>
-										<match canbuildships="true" />
-										<match canequipships="true" />
-									</match_any>
-								</match_buyer>
-							</find_buy_offer>
-						</do_elseif>
+            <!-- TODO: refactor these blocks -->
+            <!-- maxDist of 15 is the equivalent of "no limit" apparently -->
+            <!-- Finding Buyers -->
+            <do_if value="$destList == []">
+                <do_if value="$maxDist == 15">
+                    <do_if value="$tradeWithAll">
+                        <find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$needs" wares="$wareBasket" multiple="true">
+                            <match_buyer>
+                                <match_gate_distance object="$sourceStation" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                                <match_relation_to object="this.ship" relation="enemy" comparison="not" />
+                                <match tradesknownto="this.owner" />
+                                <match owner="this.ship.owner" negate="true" />
+                                <match class="class.station" />
+                                <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                                <match_parent>
+                                    <match_parent>
+                                        <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                        <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                    </match_parent>
+                                </match_parent>
+                            </match_buyer>
+                        </find_buy_offer>
+                    </do_if>
+                    <do_elseif value="$tradeWithBig">
+                        <find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$needs" wares="$wareBasket" multiple="true">
+                            <match_buyer>
+                                <match_gate_distance object="$sourceStation" min="0">
+                                    <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                </match_gate_distance>
+                                <match_relation_to object="this.ship" relation="enemy" comparison="not" />
+                                <match tradesknownto="this.owner" />
+                                <match owner="this.ship.owner" negate="true" />
+                                <match class="class.station" />
+                                <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                                <match_parent>
+                                    <match_parent>
+                                        <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                        <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                    </match_parent>
+                                </match_parent>
+                                <match_any>
+                                    <match canbuildships="true" />
+                                    <match canequipships="true" />
+                                </match_any>
+                            </match_buyer>
+                        </find_buy_offer>
+                    </do_elseif>
+                </do_if>
+                <do_else>
+                    <find_cluster_in_range distances="$clusterstable" multiple="true" object="$sourceStation.cluster" mindistance="0" maxdistance="$maxDist" />
+                    <set_value name="$sellspaces" exact="$clusterstable.keys.sorted" />
+                    <remove_value name="$clusterstable" />
+                    <do_all exact="$sellspaces.count" counter="$sector">
+                        <do_if value="$tradeWithAll">
+                            <find_buy_offer tradepartner="this.ship" space="$sellspaces.{$sector}" result="$tempList" wares="$wareBasket" multiple="true">
+                                <match_buyer>
+                                    <match_gate_distance object="$sourceStation" max="$maxDist">
+                                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                    </match_gate_distance>
+                                    <match_relation_to object="this.ship" relation="enemy" comparison="not" />
+                                    <match tradesknownto="this.owner" />
+                                    <match owner="this.ship.owner" negate="true" />
+                                    <match class="class.station" />
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                                    <match_parent>
+                                        <match_parent>
+                                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                        </match_parent>
+                                    </match_parent>
+                                </match_buyer>
+                            </find_buy_offer>
+                        </do_if>
+                        <do_elseif value="$tradeWithBig">
+                            <find_buy_offer tradepartner="this.ship" space="$sellspaces.{$sector}" result="$tempList" wares="$wareBasket" multiple="true">
+                                <match_buyer>
+                                    <match_gate_distance object="$sourceStation" max="$maxDist">
+                                        <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                                    </match_gate_distance>
+                                    <match_relation_to object="this.ship" relation="enemy" comparison="not" />
+                                    <match tradesknownto="this.owner" />
+                                    <match owner="this.ship.owner" negate="true" />
+                                    <match class="class.station" />
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                                    <match_parent>
+                                        <match_parent>
+                                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                        </match_parent>
+                                    </match_parent>
+                                    <match_any>
+                                        <match canbuildships="true" />
+                                        <match canequipships="true" />
+                                    </match_any>
+                                </match_buyer>
+                            </find_buy_offer>
+                        </do_elseif>
 
-						<do_all exact="$tempList.count" counter="$tl">
-							<append_to_list name="$needs" exact="$tempList.{$tl}" />
-						</do_all>
-					</do_all>
-				</do_else>
-				<!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'needs: ' +$needs" output="false" append="true" /> -->
-				<!-- <do_all exact="$needs.count" counter="$i"> <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="' ' +$needs.{$i}.ware + ' ' +$needs.{$i}.owner.knownname" output="false" append="true" /> </do_all> -->
-			</do_if>
-			<do_else>
-				<do_all exact="$destList.count" counter="$customer">
-					<!-- the destList was built by the user manually in the UI so dont filter by blacklist -->
-					<find_buy_offer tradepartner="this.ship" buyer="$destList.{$customer}" result="$tempList" wares="$wareBasket" multiple="true">
-						<match_buyer>
-							<match_gate_distance object="$sourceStation" max="$maxDist">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-					</find_buy_offer>
+                        <do_all exact="$tempList.count" counter="$tl">
+                            <append_to_list name="$needs" exact="$tempList.{$tl}" />
+                        </do_all>
+                    </do_all>
+                </do_else>
+                <!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'needs: ' +$needs" output="false" append="true" /> -->
+                <!-- <do_all exact="$needs.count" counter="$i"> <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="' ' +$needs.{$i}.ware + ' ' +$needs.{$i}.owner.knownname" output="false" append="true" /> </do_all> -->
+            </do_if>
+            <do_else>
+                <do_all exact="$destList.count" counter="$customer">
+                    <!-- the destList was built by the user manually in the UI so dont filter by blacklist -->
+                    <find_buy_offer tradepartner="this.ship" buyer="$destList.{$customer}" result="$tempList" wares="$wareBasket" multiple="true">
+                        <match_buyer>
+                            <match_gate_distance object="$sourceStation" max="$maxDist">
+                                <blacklist group="blacklistgroup.civilian" object="this.ship" />
+                            </match_gate_distance>
+                            <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
+                            <match_parent>
+                                <match_parent>
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
+                                    <match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
+                                </match_parent>
+                            </match_parent>
+                        </match_buyer>
+                    </find_buy_offer>
 
-					<do_all exact="$tempList.count" counter="$tl">
-						<append_to_list name="$needs" exact="$tempList.{$tl}" />
-					</do_all>
-				</do_all>
-			</do_else>
+                    <do_all exact="$tempList.count" counter="$tl">
+                        <append_to_list name="$needs" exact="$tempList.{$tl}" />
+                    </do_all>
+                </do_all>
+            </do_else>
 
-			<run_script sinceversion="2" chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
-				<param name="headerline" value="'needs'"/>
-				<param name="offers" value="$needs.clone"/>
-				<param name="debugchance" value="$debugchance"/>
-				<param name="debugFileName" value="$debugFileName"/>
-				<param name="debugDirName" value="$debugDirName"/>
-			</run_script>
+            <run_script sinceversion="2" chance="$debugchance" name="'mule.lib.debug.dump_tradeoffers'">
+                <param name="headerline" value="'needs'"/>
+                <param name="offers" value="$needs.clone"/>
+                <param name="debugchance" value="$debugchance"/>
+                <param name="debugFileName" value="$debugFileName"/>
+                <param name="debugDirName" value="$debugDirName"/>
+            </run_script>
 
-			<!-- Filter tradeoffers for capital ships if there are no cargo drones available -->
-			<!-- This could be optimized by filtering station instead of offers, but has not been done for simplicity -->
-			<do_if value="this.ship.iscapitalship and not this.ship.units.{unitcategory.transport}.count">
-				<create_list name="$filteredSupplies" />
-				<do_for_each name="$supply" in="$supplies">
-					<append_to_list chance="100*($supply.seller.units.{unitcategory.transport}.count > 0)" name="$filteredSupplies" exact="$supply"/>
-				</do_for_each>
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'filering %s selloffers due to missing cargo drones.'.[$supplies.count - $filteredSupplies.count]" />
-				<set_value name="$supplies" exact="$filteredSupplies"/>
-				<remove_value name="$filteredSupplies"/>
+            <!-- Filter tradeoffers for capital ships if there are no cargo drones available -->
+            <!-- This could be optimized by filtering station instead of offers, but has not been done for simplicity -->
+            <do_if value="this.ship.iscapitalship and not this.ship.units.{unitcategory.transport}.count">
+                <create_list name="$filteredSupplies" />
+                <do_for_each name="$supply" in="$supplies">
+                    <append_to_list chance="100*($supply.seller.units.{unitcategory.transport}.count > 0)" name="$filteredSupplies" exact="$supply"/>
+                </do_for_each>
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'filering %s selloffers due to missing cargo drones.'.[$supplies.count - $filteredSupplies.count]" />
+                <set_value name="$supplies" exact="$filteredSupplies"/>
+                <remove_value name="$filteredSupplies"/>
 
-				<create_list name="$filteredNeeds" />
-				<do_for_each name="$need" in="$needs">
-					<append_to_list chance="100*($need.buyer.units.{unitcategory.transport}.count > 0)" name="$filteredNeeds" exact="$need"/>
-				</do_for_each>
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'filering %s buyoffers due to missing cargo drones.'.[$needs.count - $filteredNeeds.count]" />
-				<set_value name="$needs" exact="$filteredNeeds"/>
-				<remove_value name="$filteredNeeds"/>
-			</do_if>
+                <create_list name="$filteredNeeds" />
+                <do_for_each name="$need" in="$needs">
+                    <append_to_list chance="100*($need.buyer.units.{unitcategory.transport}.count > 0)" name="$filteredNeeds" exact="$need"/>
+                </do_for_each>
+                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'filering %s buyoffers due to missing cargo drones.'.[$needs.count - $filteredNeeds.count]" />
+                <set_value name="$needs" exact="$filteredNeeds"/>
+                <remove_value name="$filteredNeeds"/>
+            </do_if>
 
-			<!-- Regular Travelling Mule Routine -->
-			<do_if value="$needs.count gt 0 and $supplies.count gt 0">
-				<set_value name="$innerList" exact="$needs" />
-				<sort_trades name="$outerList" tradelist="$supplies" sorter="volume" />
-				
-				<set_value name="$needFound" exact="false" />
-				<set_value name="$supplyTarget" exact="0" />
-				<set_value name="$supplySource" exact="0" />
-				<set_value name="$bestProfit" exact="0" />
-				<set_value name="$bestCargo" exact="0" />
-				<set_value name="$currentProfit" exact="0" />
+            <!-- Regular Travelling Mule Routine -->
+            <do_if value="$needs.count gt 0 and $supplies.count gt 0">
+                <set_value name="$innerList" exact="$needs" />
+                <sort_trades name="$outerList" tradelist="$supplies" sorter="volume" />
+                
+                <set_value name="$needFound" exact="false" />
+                <set_value name="$supplyTarget" exact="0" />
+                <set_value name="$supplySource" exact="0" />
+                <set_value name="$bestProfit" exact="0" />
+                <set_value name="$bestCargo" exact="0" />
+                <set_value name="$currentProfit" exact="0" />
 
-				<do_all exact="$outerList.count" counter="$idx">
-					<do_if value="not $needFound">
-						<set_value name="$someOuter" exact="$outerList.{$idx}" />
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Comparing %s'.[$someOuter.ware.name]" output="false" append="true" />
-						<do_all exact="$innerList.count" counter="$ctr">
-							<set_value name="$someInner" exact="$innerList.{$ctr}" />
-							<do_if value="$someOuter.ware.id" exact="$someInner.ware.id">
-								<!-- find need -->
-								<do_if value="$someInner.owner.owner == this.ship.owner">
-									<set_value name="$targetAmount" exact="$someInner.desiredamount" />
-								</do_if>
-								<do_else>
-									<set_value name="$targetAmount" exact="$someInner.amount" />
-								</do_else>
+                <do_all exact="$outerList.count" counter="$idx">
+                    <do_if value="not $needFound">
+                        <set_value name="$someOuter" exact="$outerList.{$idx}" />
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Comparing %s'.[$someOuter.ware.name]" output="false" append="true" />
+                        <do_all exact="$innerList.count" counter="$ctr">
+                            <set_value name="$someInner" exact="$innerList.{$ctr}" />
+                            <do_if value="$someOuter.ware.id" exact="$someInner.ware.id">
+                                <!-- find need -->
+                                <do_if value="$someInner.owner.owner == this.ship.owner">
+                                    <set_value name="$targetAmount" exact="$someInner.desiredamount" />
+                                </do_if>
+                                <do_else>
+                                    <set_value name="$targetAmount" exact="$someInner.amount" />
+                                </do_else>
 
-								<!-- trade rule handling -->
-								<!-- the buyoffer faction needs to be allowed by the selloffer faction, and vice-versa -->
-								<set_value name="$someNeedRestrictionFactions" exact="$someInner.restriction.factions" />
-								<set_value name="$someNeedRestrictionInverted" exact="$someInner.restriction.inverted" />
-								<set_value name="$someSupplyRestrictionFactions" exact="$someOuter.restriction.factions" />
-								<set_value name="$someSupplyRestrictionInverted" exact="$someOuter.restriction.inverted" />
+                                <!-- trade rule handling -->
+                                <!-- the buyoffer faction needs to be allowed by the selloffer faction, and vice-versa -->
+                                <set_value name="$someNeedRestrictionFactions" exact="$someInner.restriction.factions" />
+                                <set_value name="$someNeedRestrictionInverted" exact="$someInner.restriction.inverted" />
+                                <set_value name="$someSupplyRestrictionFactions" exact="$someOuter.restriction.factions" />
+                                <set_value name="$someSupplyRestrictionInverted" exact="$someOuter.restriction.inverted" />
 
-								<!-- this debug block is useful for trade rule debugging and I want to leave it in the script for a while -->
-								<!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*******************************'" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someNeedRestrictionFactions" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someNeedRestrictionInverted" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupplyRestrictionFactions" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupplyRestrictionInverted" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupply.seller.owner" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +typeof $someSupply.seller.owner" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +(not $someNeedRestrictionFactions.indexof.{$someSupply.seller.owner})" /> -->
+                                <!-- this debug block is useful for trade rule debugging and I want to leave it in the script for a while -->
+                                <!-- <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*******************************'" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someNeedRestrictionFactions" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someNeedRestrictionInverted" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupplyRestrictionFactions" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupplyRestrictionInverted" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +$someSupply.seller.owner" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +typeof $someSupply.seller.owner" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'*_*_*_ ' +(not $someNeedRestrictionFactions.indexof.{$someSupply.seller.owner})" /> -->
 
-								<!-- trade rules are a bit wonky -->
-								<!-- if tradeoffer.restriction.inverted == 1, then the list returned by tradeoffer.restriction.factions is a blacklist. -->
-								<!-- This corresponds to leaving "restrict all factions" blank in the trade rule UI -->
-								<!-- if tradeoffer.restriction.inverted == 0, then the list returned by tradeoffer.restriction.factions is a whitelist. -->
-								<!-- This corresponds to checking the box for "restrict all factions" in the trade rule UI -->
-								<!-- so we have a buyer and a seller. We need to determine if either one is disallowed from the other -->
-								<!-- buyer whitelist case -->
-								<!-- inverted == 0 and supply owner not in the whitelist -->
-								<do_if value="($someNeedRestrictionInverted == 0) and (not $someNeedRestrictionFactions.indexof.{$someOuter.seller.owner})">
-									<continue />
-								</do_if>
-								<!-- buyer blacklist case -->
-								<!-- inverted == 1 and supply owner in blacklist -->
-								<do_elseif value="($someNeedRestrictionInverted == 1) and ( $someNeedRestrictionFactions.indexof.{$someOuter.seller.owner})">
-									<continue />
-								</do_elseif>
-								<!-- seller whitelist case -->
-								<!-- inverted == 0 and need owner not in whitelist -->
-								<do_elseif value="($someSupplyRestrictionInverted == 0) and (not $someSupplyRestrictionFactions.indexof.{$someInner.buyer.owner})">
-									<continue />
-								</do_elseif>
-								<!-- seller blacklist case -->
-								<!-- inverted == 1 and supply owner in blacklist -->
-								<do_elseif value="($someSupplyRestrictionInverted == 1) and ( $someSupplyRestrictionFactions.indexof.{$someInner.buyer.owner})">
-									<continue />
-								</do_elseif>
+                                <!-- trade rules are a bit wonky -->
+                                <!-- if tradeoffer.restriction.inverted == 1, then the list returned by tradeoffer.restriction.factions is a blacklist. -->
+                                <!-- This corresponds to leaving "restrict all factions" blank in the trade rule UI -->
+                                <!-- if tradeoffer.restriction.inverted == 0, then the list returned by tradeoffer.restriction.factions is a whitelist. -->
+                                <!-- This corresponds to checking the box for "restrict all factions" in the trade rule UI -->
+                                <!-- so we have a buyer and a seller. We need to determine if either one is disallowed from the other -->
+                                <!-- buyer whitelist case -->
+                                <!-- inverted == 0 and supply owner not in the whitelist -->
+                                <do_if value="($someNeedRestrictionInverted == 0) and (not $someNeedRestrictionFactions.indexof.{$someOuter.seller.owner})">
+                                    <continue />
+                                </do_if>
+                                <!-- buyer blacklist case -->
+                                <!-- inverted == 1 and supply owner in blacklist -->
+                                <do_elseif value="($someNeedRestrictionInverted == 1) and ( $someNeedRestrictionFactions.indexof.{$someOuter.seller.owner})">
+                                    <continue />
+                                </do_elseif>
+                                <!-- seller whitelist case -->
+                                <!-- inverted == 0 and need owner not in whitelist -->
+                                <do_elseif value="($someSupplyRestrictionInverted == 0) and (not $someSupplyRestrictionFactions.indexof.{$someInner.buyer.owner})">
+                                    <continue />
+                                </do_elseif>
+                                <!-- seller blacklist case -->
+                                <!-- inverted == 1 and supply owner in blacklist -->
+                                <do_elseif value="($someSupplyRestrictionInverted == 1) and ( $someSupplyRestrictionFactions.indexof.{$someInner.buyer.owner})">
+                                    <continue />
+                                </do_elseif>
 
-								<set_value name="$cargoHauled" exact="[this.ship.cargo.{$someInner.ware}.free,$targetAmount,$someOuter.amount].min" />
-								<set_value name="$currentProfit" exact="$cargoHauled * ($someInner.unitprice - $someOuter.unitprice*$profitMargin/100.0)" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----' + player.age" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'cargoHauled: ' +$cargoHauled" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buyer.unitprice: ' +$someInner.unitprice" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'seller.unitprice: ' +$someOuter.unitprice" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'currentProfit: ' +$currentProfit" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'bestProfit: ' +$bestProfit" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'minCargoUsed/100.0: ' +($minCargoUsed)f/100.0" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'minCargoUsed: ' +$minCargoUsed" output="false" append="true" />
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'this.ship.cargo.ware.max div 1.25: ' +this.ship.cargo.{$someInner.ware}.max / 1.25" output="false" append="true" />
+                                <set_value name="$cargoHauled" exact="[this.ship.cargo.{$someInner.ware}.free,$targetAmount,$someOuter.amount].min" />
+                                <set_value name="$currentProfit" exact="$cargoHauled * ($someInner.unitprice - $someOuter.unitprice*$profitMargin/100.0)" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'----' + player.age" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'cargoHauled: ' +$cargoHauled" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'buyer.unitprice: ' +$someInner.unitprice" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'seller.unitprice: ' +$someOuter.unitprice" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'currentProfit: ' +$currentProfit" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'bestProfit: ' +$bestProfit" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'minCargoUsed/100.0: ' +($minCargoUsed)f/100.0" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'minCargoUsed: ' +$minCargoUsed" output="false" append="true" />
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'this.ship.cargo.ware.max div 1.25: ' +this.ship.cargo.{$someInner.ware}.max / 1.25" output="false" append="true" />
 
-								<do_if value="($currentProfit gt $bestProfit) and (($cargoHauled)f/(this.ship.cargo.{$someInner.ware}.max)) gt $minCargoUsed/100.0">
-									<set_value name="$supplyTarget" exact="$someInner" />
-									<set_value name="$bestCargo" exact="$cargoHauled" />
-									<set_value name="$bestProfit" exact="$currentProfit" />
-									<do_if value="not $needFound">
-										<set_value name="$needFound" exact="true" />
-										<set_value name="$supplySource" exact="$someOuter" />
-									</do_if>
-								</do_if>
-							</do_if> <!-- need found -->
-						</do_all>
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'need found: ' +$needFound" output="false" append="true" />
+                                <do_if value="($currentProfit gt $bestProfit) and (($cargoHauled)f/(this.ship.cargo.{$someInner.ware}.max)) gt $minCargoUsed/100.0">
+                                    <set_value name="$supplyTarget" exact="$someInner" />
+                                    <set_value name="$bestCargo" exact="$cargoHauled" />
+                                    <set_value name="$bestProfit" exact="$currentProfit" />
+                                    <do_if value="not $needFound">
+                                        <set_value name="$needFound" exact="true" />
+                                        <set_value name="$supplySource" exact="$someOuter" />
+                                    </do_if>
+                                </do_if>
+                            </do_if> <!-- need found -->
+                        </do_all>
+                        <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'need found: ' +$needFound" output="false" append="true" />
 
-						<do_if value="$needFound">
-							<do_if value="$supplySource.owner.owner == this.ship.owner">
-								<set_value name="$currentProfit" exact="$bestCargo * $supplyTarget.unitprice" />
-								<write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100" />
+                        <do_if value="$needFound">
+                            <do_if value="$supplySource.owner.owner == this.ship.owner">
+                                <set_value name="$currentProfit" exact="$bestCargo * $supplyTarget.unitprice" />
+                                <write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100" />
 
-								<!-- Debug: Print profit stats to logfile -->
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
+                                <!-- Debug: Print profit stats to logfile -->
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at -- (player owned) to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
 
-							</do_if>
-							<do_else>
-								<set_value name="$currentProfit" exact="$bestCargo * ($supplyTarget.unitprice - $supplySource.unitprice)" />
-								<write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100.0 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
+                            </do_if>
+                            <do_else>
+                                <set_value name="$currentProfit" exact="$bestCargo * ($supplyTarget.unitprice - $supplySource.unitprice)" />
+                                <write_to_logbook category="upkeep" title="'Travel Mule: '+this.ship.knownname" interaction="showonmap" object="this.ship" money="$currentProfit" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100.0 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
 
-								<!-- Debug: Print profit stats to logfile -->
-								<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100.0 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
+                                <!-- Debug: Print profit stats to logfile -->
+                                <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Buying ' +$bestCargo + ' ' +$supplySource.ware + ' from ' +$supplySource.seller.knownname + ' at ' +$supplySource.unitprice/100.0 + ' to sell to ' + $supplyTarget.buyer.knownname + ' at ' +$supplyTarget.unitprice/100.0 + ' for a profit of ' +$currentProfit/100.0" />
 
-							</do_else>
+                            </do_else>
 
-							<create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$bestCargo" immediate="false" />
-							<create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$bestCargo" immediate="false" />
-						</do_if>
-					</do_if>
-				</do_all>
-			</do_if> <!-- the stations have supply and demand -->
+                            <create_trade_order name="$getSupply" object="this.object" tradeoffer="$supplySource" amount="$bestCargo" immediate="false" />
+                            <create_trade_order name="$dropSupply" object="this.object" tradeoffer="$supplyTarget" amount="$bestCargo" immediate="false" />
+                        </do_if>
+                    </do_if>
+                </do_all>
+            </do_if> <!-- the stations have supply and demand -->
 
-			<remove_value name="$supplyTarget" />
-			<remove_value name="$supplySource" />
-			<remove_value name="$supplies" />
-			<remove_value name="$needs" />
-			<remove_value name="$innerList" />
-			<remove_value name="$outerList" />
+            <remove_value name="$supplyTarget" />
+            <remove_value name="$supplySource" />
+            <remove_value name="$supplies" />
+            <remove_value name="$needs" />
+            <remove_value name="$innerList" />
+            <remove_value name="$outerList" />
 
-			<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Nothing found, check back in a couple of minuites....'" />
-			<wait min="3min" max="5min" />
-			<label name="end" />
-			<return/>
-			<!-- Absolutly ridicules workaround to surpress any messages related to blocking actions -->
-			<!-- Basicially, we add a bunch of blocking actions that are never reached. -->
-			<!-- This ensures, that our block action index in the savegames never exceeds the actual number of blocking actions. -->
-			<!-- Therefore, if we were to delete a blocking action above, the savegame will load without throwing an error message -->
-			<!-- Note, that the script state in this case is totally wrong, since the game will load the variables from the last game. -->
-			<!-- This is mitiagted, by restarting the order with a´patch command on load. -->
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-			<wait chance="0"/>
-		</actions>
-	</attention>
+            <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Nothing found, check back in a couple of minuites....'" />
+            <wait min="3min" max="5min" />
+            <label name="end" />
+            <return/>
+            <!-- Absolutly ridicules workaround to surpress any messages related to blocking actions -->
+            <!-- Basicially, we add a bunch of blocking actions that are never reached. -->
+            <!-- This ensures, that our block action index in the savegames never exceeds the actual number of blocking actions. -->
+            <!-- Therefore, if we were to delete a blocking action above, the savegame will load without throwing an error message -->
+            <!-- Note, that the script state in this case is totally wrong, since the game will load the variables from the last game. -->
+            <!-- This is mitiagted, by restarting the order with a´patch command on load. -->
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+            <wait chance="0"/>
+        </actions>
+    </attention>
 </aiscript>

--- a/aiscripts/travel_mule.xml
+++ b/aiscripts/travel_mule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<aiscript name="travelmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="3">
+<aiscript name="travelmule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd" version="4">
 	<!-- Setup context menu order -->
 	<order id="TravelMule" name="{61552,1001}" description="{61552,1101}" category="trade" infinite="true">
 		<params>
@@ -49,6 +49,8 @@
 			<param name="destList" required="false" default="[]" type="list" text="{61552,1010}" comment="{61552,1110}">
 				<input_param name="type" value="'object'" />
 			</param>
+			<param name="restartScript" type="internal" default="false"/>
+
 		</params>
 		<requires>
 			<!-- The requirements of ships in order to be eligible get this order (requirements can be skill-level requirements or ship-type requirements) -->
@@ -79,9 +81,10 @@
 		</do_if>
 		<set_value name="$debugFileName" exact="'travelmule - ' + this.ship.idcode" />
 		<set_value name="$debugDirName" exact="'MulesExtended'"/>
+		<set_value name="$logbookEntryTitle" exact="'TravelMule: '+this.ship.knownname +' ( '+this.ship.idcode+' )'"/>
 	</init>
 	
-	<patch sinceversion="2">
+	<patch sinceversion="4">
 		<!-- This will reissue any standing travel mule orders -->
 		<!-- it should mitigate any problems with blocking actions beeing updated inbetween savegames -->
 		<debug_text text="'PATCH: Restarting travel mule script on load for version safety on mule %s'.[this.ship.idcode]" filter="savegame"/>
@@ -101,64 +104,18 @@
 			<create_list name="$outerList" />
 			<create_list name="$tempList" />
 
-			<!-- Sell leftover cargo before resuming regular Mule routine -->
-			<set_value name="$profitScale" exact="50" />
-			<set_value name="$pilotSkill" exact="this.ship.pilot.skill.piloting" />
-			<set_value name="$maxBuyRelPrice" exact="((-0.325-0.025*($pilotSkill)f)/90.0-0.01)*($profitScale)f+1-(-0.325-0.025*($pilotSkill)f)/9.0" />
-			<set_value name="$searchStep" exact="(1.0-$maxBuyRelPrice)/4.0" />
-
+			<!-- Sell leftover cargo at averageprice (to nobody) before resuming regular Mule routine -->
 			<set_value name="$cargo" exact="this.ship.cargo.list" />
 
-			<do_all exact="$cargo.count" counter="$wareInCargo">
-				<wait min="50ms" max="150ms" />
-
-				<set_value name="$currentWare" exact="$cargo.{$wareInCargo}" />
-				<set_value name="$amount" exact="this.ship.cargo.{$currentWare}.count" />
-				<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'trying to sell '+$amount+' '+$currentWare+' from cargo'" />
-
-				<do_all exact="5" counter="$reduction">
-					<!-- searching suiting buy offer, will search 5 times reducing requirements each time by 20% (just want to get rid of that stuff at some point) -->
-					<find_buy_offer tradepartner="this.ship" space="player.galaxy" result="$buyOffer" wares="$currentWare">
-						<match_buyer tradesknownto="this.owner">
-							<match_gate_distance object="this.ship" min="0" max="$maxDist">
-								<blacklist group="blacklistgroup.civilian" object="this.ship" />
-							</match_gate_distance>
-							<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.objectactivity" object="this.ship" />
-							<match_parent>
-								<match_parent>
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectortravel" object="this.ship" />
-									<match_use_blacklist group="blacklistgroup.civilian" type="blacklisttype.sectoractivity" object="this.ship" />
-								</match_parent>
-							</match_parent>
-						</match_buyer>
-						<relativeprice min="-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001" />
-						<amount min="$amount*(0.8^($reduction-1))" />
-					</find_buy_offer>
-					<wait min="50ms" max="150ms" />
-
-					<do_if value="$buyOffer == null">
-						<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  could not find buyer for min amount: '+$amount*(0.8^($reduction-1))+ ' min relative price: '+(-$maxBuyRelPrice-(($reduction)f-1.0)*$searchStep-0.001)+', max gates :8'" />
-						<continue />
-					</do_if>
-
-					<set_value name="$amount" exact="[$amount,$buyOffer.amount].min" />
-
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  found buyer: ownername: '+$buyOffer.owner.knownname+'('+$buyOffer.owner.owner.knownname+'), unitprice: '+$buyOffer.unitprice+', amount: '+$buyOffer.amount+', relative price: '+$buyOffer.relativeprice+', totalprice: '+$buyOffer.price+', sector: '+$buyOffer.owner.sector.knownname+', gates from this ship: '+$buyOffer.owner.gatedistance.{this.ship}+', gates from home (from ship if not homebound): '+$buyOffer.owner.gatedistance.{this.ship}+'. selling amount: '+$amount" />
-
-					<do_if value="$buyOffer.available">
-						<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" money="$buyOffer.unitprice*$amount" text="'Selling '+$amount+' '+$currentWare+', unitprice: '+$buyOffer.unitprice/100.0" />
-						<create_trade_order object="this.ship" amount="$amount" tradeoffer="$buyOffer" />
-						<debug_to_file name="$debugFileName" directory="$debugDirName" text="'  trade created'" />
-						<resume label="end" />
-					</do_if>
-					<debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'  offer not available anymore'" />
-				</do_all>
-				<show_notification text="['TravelMule: '+this.ship.knownname+' ('+this.ship.idcode+')', '', 'can\'t empty cargo', [$amount+' '+$currentWare, 255, 192, 126]]" sound="notification_warning" />
-				<write_to_logbook category="general" title="'TravelMule: '+this.ship.knownname+' ( '+this.ship.idcode+' )'" interaction="showonmap" object="this.ship" text="'can\'t get rid of '+$amount+' '+$currentWare+' from cargo, what should I do?'" />
-			</do_all>
-			<remove_value name="$searchStep" />
-			<remove_value name="$cargo" />
-			<remove_value name="$buyOffer" />
+			<do_if value="$cargo.count gt 0">
+				<run_script name="'mule.lib.empty_cargo'">
+					<param name="debugchance" value="$debugchance" />
+					<param name="debugFileName" value="$debugFileName" />
+					<param name="debugDirName" value="$debugDirName" />
+					<param name="logbookEntryTitle" value="$logbookEntryTitle" />
+					<param name="cargo" value="$cargo" />
+				</run_script>
+			</do_if>
 
 			<do_if value="this.ship.cargo.free.container lt (this.ship.cargo.capacity.container/10.0)">
 				<debug_to_file chance="$debugchance" name="$debugFileName" directory="'TravelMule'" text="'  cargo is full =('" />


### PR DESCRIPTION
- replaces cargo emptying routine with a new mule.lib.empty_cargo script
- Rather than looking for an AI trade partner, deletes the ware and gives the player money at the ware's averageprice
- intended to reduce user bug reports on mules selling to the AI when they're not supposed to
- The cargo emptying is typically triggered either on first setting a mule up, if he already has cargo, or when the game cancels a trade that has become invalid during transit