### PR TITLE
fixes list reference bug

### DIFF
--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -270,7 +270,7 @@
             <set_value name="$isServingStationOrShip" exact="if ($homeStationOrShip != null) then true else false"/>
             <set_value name="$isServingSector" exact="if (($home.isclass.sector and $dedicatedServe) or ($home.isclass.{[class.ship, class.station]} and not $dedicatedServe)) then true else false"/>
             <set_value name="$isServingPlayer" exact="(not $isServingStationOrShip) or ($homeStationOrShip.owner == faction.player)" />
-            <set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions else $aiFactions" />
+            <set_value name="$serveFactions" exact="if ($isServingPlayer) then $playerFactions.clone else $aiFactions.clone" />
             <set_value name="$isServingArea" exact="$isServingPlayer and (not $dedicatedServe)" />
             <set_value name="$isDedicatedPlayerBuilder" exact="$isServingPlayer and $allowBuildstorage and (not $allowResources) and (not $allowIntermediates) and (not $allowTradewares)" />
 


### PR DESCRIPTION
Assigning a list as a copy of another list actually makes a reference, not a true copy. So we were inadvertently using the "Collect from Player" and "Collect from AI" options to remove the player/ai factions from the priorities for RECEIVING supply, not just providing it. It made the options appear as if they were controlling ALL trades with the player/AI, when they were intended just to apply to the first trade (i.e. where the mule collects the ware from, to supply to the station in need). 

This fixes the bug by cloning the underlying lists, which makes a shallow copy (shallow is fine as there's no nesting in this particular list).

Fixes https://github.com/Misunderstood-Wookiee/Mules-and-Warehouses-Extended/issues/154