### PR TITLE
Fix Mimic command in 7.0 to allow mimic in mule fleet

### DIFF
--- a/aiscripts/order.assist.xml
+++ b/aiscripts/order.assist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4dynlib.access.ly\libraries\aiscripts.xsd">
-<add sel="//do_if[@value='not $order.requiredskill or (this.combinedskill ge $order.requiredskill)']">
+<add sel="//do_if[@value='(@$orderdef and $createdefaultorder?) or not $order.requiredskill or (this.combinedskill ge $order.requiredskill)']">
 	<do_if value="$order.id == 'SupplyMule'">
 		<set_value name="$added"/>
 		<run_script name="$scriptname">


### PR DESCRIPTION
Fix selector in order.assist.xml line 3 to match with new 7.0 xml structure.  Now player can use mimic command in Mule fleet