### PR TITLE
Fixing the newline issue

### DIFF
--- a/t/0001.xml
+++ b/t/0001.xml
@@ -18,10 +18,8 @@
 		<t id="1101">Ferries supplies between stations</t>
 		<t id="1102">The source station</t>
 		<t id="1103">Max Gate Distance to sell.</t>
-		<t id="1104">Owned Station Buy price adjustment, 0=Sell all wares regardless of trade offer
-			price. 100= Obey Station Manager's buy offer.</t>
-		<t id="1105">Locks the Users ware selection, otherwise we need to wipe it each time we call
-			the script</t>
+		<t id="1104">Owned Station Buy price adjustment, 0=Sell all wares regardless of trade offer price. 100= Obey Station Manager's buy offer.</t>
+		<t id="1105">Locks the Users ware selection, otherwise we need to wipe it each time we call the script</t>
 		<t id="1106">Which Wares to consider in the trade.</t>
 		<t id="1107">The percentage of the ship's cargo hold that the trade will take up.</t>
 		<t id="1108">Assign to trade with all NPC shipyards, wharfs, and equip docks.</t>
@@ -115,12 +113,10 @@
 		<t id="4109">Allows buys for Resources.</t>
 		<t id="4110">Allows buys for Intermediates.</t>
 		<t id="4111">Allows buys for Trade Wares.</t>
-		<t id="4112">Locks the ware selection, otherwise we need to wipe it each time we call the
-			script.</t>
+		<t id="4112">Locks the ware selection, otherwise we need to wipe it each time we call the script.</t>
 		<t id="4113">Warebasket</t>
 		<t id="4114">Max Trades per buy run.</t>
-		<t id="4115">Owned Station Buy price adjustment, 0=ignore manager price 100= Obey Station
-			Manager's buy offer.</t>
+		<t id="4115">Owned Station Buy price adjustment, 0=ignore manager price 100= Obey Station Manager's buy offer.</t>
 		<t id="4116">Buys from player stations only</t>
 		<t id="4117">Will wait for build storage needs instead of finding something to do.</t>
 		<t id="4118">Will look to supply only factories with products.</t>
@@ -128,7 +124,6 @@
 		<t id="4120">Assign to the home station if it's the players.</t>
 		<t id="4121">Max Trades per buy run.</t>
 		<t id="4122">The percentage of the ship's cargo hold that the trade will take up.</t>
-		<t id="4123">If you are experiencing lag spikes from supply mules, reduce this to lower the
-			number of evaluated trades</t>
+		<t id="4123">If you are experiencing lag spikes from supply mules, reduce this to lower the number of evaluated trades</t>
 	</page>
 </language>


### PR DESCRIPTION
This fixes #168.

Honestly, it feels like the raw newlines were introduced because the XML editor was strict on enforcing maximum line width. But in practice, it is entirely OK for the t-files to have extra long lines of text. Even the vanilla t-files occasionally have very long texts all in the same line to represent e.g. sector description lore text.