### PR TITLE
Fix supply mule stuttering (#161)

### DIFF
--- a/aiscripts/mule.lib.evaluate_tradeoffers.xml
+++ b/aiscripts/mule.lib.evaluate_tradeoffers.xml
@@ -25,6 +25,8 @@
 	</params>
 	<attention min="unknown">
 		<actions>
+			<!-- Yield to prevent instant return causing infinite wake loops (issue #161) -->
+			<wait exact="1ms" />
 			<!-- Default values for best trade -->
 			<set_value name="$bestProfit" exact="0Cr" />
 			<set_value name="$bestAmount" exact="0" />

--- a/aiscripts/supply_mule.xml
+++ b/aiscripts/supply_mule.xml
@@ -529,6 +529,8 @@
                     <set_value name="$occupiedCargo" exact="$ShipCapacity - this.ship.cargo.free.all" />
                     <set_value name="$emergencyBreak" exact="0"/>
                     <do_while value="true">
+                        <!-- Prevent tight loop that causes game stuttering (issue #161) -->
+                        <wait exact="1ms" />
                         <debug_to_file chance="$debugchance" name="$debugFileName" directory="$debugDirName" text="'Occupied Cargo: ' + $occupiedCargo" />
 
                         <!-- emergency break to prevent mule from freezing the screen (in theory they should never crash) -->


### PR DESCRIPTION
Add 1ms wait to the trade evaluation loop and library to prevent tight loops when no valid trades are found.

In my testing im running stable with ~ 40 Supply Mules assigned to one station 