### PR TITLE
Fix X4 9.0: null-safe path access in lib.request.orders

### DIFF
--- a/aiscripts/lib.request.orders.xml
+++ b/aiscripts/lib.request.orders.xml
@@ -29,7 +29,11 @@ Now possible to assign Mules to station with assignment="assignment.trade" while
 
             Overall, this has the effect of checking if the ship is running our Mules command
         -->
-        <do_if value="$object.defaultorder? and global.$mwex_AllMulesCommandTags.indexof.{($object.defaultorder).id}">
+        <!-- X4 9.0 fix: use vanilla-idiom @-prefix null-safe path access.
+             Both parse-time validation AND runtime succeed because @$object.defaultorder.id
+             returns null if any link is null; indexof.{null} returns 0 (false), so the
+             whole expression safely evaluates to false when ship has no default order. -->
+        <do_if value="global.$mwex_AllMulesCommandTags.indexof.{@$object.defaultorder.id}">
             <set_value name="$flag_mwex_shipismule" exact="true" comment="Actual value not important; we simply need this variable to be here" />
         </do_if>
     </add>


### PR DESCRIPTION
X4 9.0 evaluates short-circuit expressions more strictly than 8.x. The previous guard `$object.defaultorder?` returns true based on schema-declared property existence, not value-null state. In 9.0 the second operand of `and` then dereferences `($object.defaultorder).id` on a null link, producing a parse/lookup failure and dropping the entire mule-exempt branch. Ships running Mule orders fall through to the vanilla AutoTrade logic and get stuck on docking.

Replace with the vanilla 9.0 idiom: `@$object.defaultorder.id`. The `@` prefix makes the whole path null-safe — any null link yields null, and `indexof.{null}` returns 0 (false). One expression covers both the existence check and the id lookup, valid at parse time and safe at runtime.

Verified in 9.0:
- M2 (StationMule) — init OK + actions ENTERED, ship trades
- M4 (SupplyMule)  — init OK + actions ENTERED, ship trades
- Zero `null.id` errors in debug.log
- Zero `defaultorder` lookup failures